### PR TITLE
Fix template assigning error

### DIFF
--- a/data/ProfileManager.h
+++ b/data/ProfileManager.h
@@ -155,7 +155,7 @@ public:
         if ( profiles.contains(profileName) )
         {
             profilesMutex.lock();
-            T ret = profiles.value(profileName).value<T>();
+            T ret = profiles.value(profileName).template value<T>();
             profilesMutex.unlock();
             return ret;
         }


### PR DESCRIPTION
See https://stackoverflow.com/a/3786481 for reference

When the name of a member template specialization appears
after . or -> in a postfix-expression, or after nested-name-specifier
in a qualified-id, and the postfix-expression or qualified-id explicitly
depends on a template-parameter (14.6.2), the member template name must be
prefixed by the keyword template. Otherwise the name is assumed to name a
non-template.