### PR TITLE
Fix MacOS builds

### DIFF
--- a/ui/DxWidget.cpp
+++ b/ui/DxWidget.cpp
@@ -451,7 +451,11 @@ void DxWidget::connected()
     }
     else
     {
+#ifndef Q_OS_MACOS
         if ( setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &maxIdle, sizeof(maxIdle)) != 0 )
+#else
+        if ( setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &maxIdle, sizeof(maxIdle)) != 0 )
+#endif /* Q_OS_MACOS */
         {
             qWarning() << "Cannot set keepalive idle for DXC";
         }

--- a/ui/PaperQSLDialog.cpp
+++ b/ui/PaperQSLDialog.cpp
@@ -43,7 +43,7 @@ void PaperQSLDialog::addFileClick()
                                                     "",
 #if defined(Q_OS_WIN)
                                                     ""
-#elif (Q_OS_MACOS)
+#elif defined(Q_OS_MACOS)
                                                     ""
 #else
                                                     ""

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -873,7 +873,7 @@ void SettingsDialog::tqslPathBrowse()
                                                     "",
 #if defined(Q_OS_WIN)
                                                     "TQSL (*.exe)"
-#elif (Q_OS_MACOS)
+#elif defined(Q_OS_MACOS)
                                                     "TQSL (*.app)"
 #else
                                                     "TQSL (tqsl)"


### PR DESCRIPTION
- See https://man7.org/linux/man-pages/man7/tcp.7.html for reference:
  TCP_KEEPIDLE (since Linux 2.4)
      The time (in seconds) the connection needs to remain idle
      before TCP starts sending keepalive probes, if the socket
      option SO_KEEPALIVE has been set on this socket.  This
      option should not be used in code intended to be portable.
  Flag is replaced with TCP_KEEPALIVE for OS X only.
- Added missing 'defined' keyword macro into:
  - PaperQSLDialog::addFileClick()
  - SettingsDialog::tqslPathBrowse()