### PR TITLE
handle call area suffixes

### DIFF
--- a/core/Callsign.cpp
+++ b/core/Callsign.cpp
@@ -21,6 +21,7 @@ Callsign::Callsign(const QString &callsign,
         hostPrefixWithDelimiter = match.captured(1);
         hostPrefix              = match.captured(2);
         base                    = match.captured(3);
+        basePrefix              = match.captured(4);
         suffixWithDelimiter     = match.captured(7);
         suffix                  = match.captured(8);
 
@@ -71,6 +72,13 @@ QString Callsign::getBase() const
     FCT_IDENTIFICATION;
 
     return base;
+}
+
+QString Callsign::getBasePrefix() const
+{
+    FCT_IDENTIFICATION;
+
+    return basePrefix;
 }
 
 QString Callsign::getSuffix() const

--- a/core/Callsign.h
+++ b/core/Callsign.h
@@ -17,6 +17,7 @@ public:
     QString getHostPrefix() const;
     QString getHostPrefixWithDelimiter() const;
     QString getBase() const;
+    QString getBasePrefix() const;
     QString getSuffix() const;
     QString getSuffixWithDelimiter() const;
     bool isValid() const;
@@ -26,6 +27,7 @@ private:
     QString hostPrefix;
     QString hostPrefixWithDelimiter;
     QString base;
+    QString basePrefix;
     QString suffix;
     QString suffixWithDelimiter;
     bool valid;

--- a/data/Data.cpp
+++ b/data/Data.cpp
@@ -991,6 +991,7 @@ DxccEntity Data::lookupDxcc(const QString &callsign)
         }
 
         QString lookupPrefix = callsign; // use the callsign with optional prefix as default to find the dxcc
+        QStringList specialSuffixes = { "AM", "MM", "QRP" }; // a list of suffixes that have a special meaning
 
         Callsign parsedCallsign(callsign); // use Callsign to split the callsign into its parts
         if ( parsedCallsign.isValid() ) {
@@ -1001,7 +1002,7 @@ DxccEntity Data::lookupDxcc(const QString &callsign)
                 if ( isNumber ) {
                     lookupPrefix = parsedCallsign.getBasePrefix() + suffix; // use the call prefix and the number from the suffix to find the dxcc
                 }
-            } else if ( suffix.length() > 1 ) { // if there is more than one character we definitely have a call prefix as suffix
+            } else if ( suffix.length() > 1 && !specialSuffixes.contains(suffix) ) { // if there is more than one character and it is not one of the special suffixes, we definitely have a call prefix as suffix
                 lookupPrefix = suffix;
             }
         }


### PR DESCRIPTION
In the callsign KH6XX/W0, the actual DXCC is determined by the suffix W0 instead of the callsign prefix KH6

Resolves #226