### PR TITLE
Add AppStream metainfo file

### DIFF
--- a/QLog.pro
+++ b/QLog.pro
@@ -322,7 +322,8 @@ RESOURCES += \
 OTHER_FILES += \
     res/stylesheet.css \
     res/qlog.rc \
-    res/qlog.desktop
+    res/qlog.desktop \
+    res/io.github.foldynl.QLog.metainfo.xml
 
 TRANSLATIONS = i18n/qlog_de.ts \
                i18n/qlog_cs.ts
@@ -372,7 +373,10 @@ unix:!macx {
    icon.path = $$PREFIX/share/icons/hicolor/256x256/apps
    icon.files += res/$${TARGET}.png
 
-   INSTALLS += target desktop icon
+   metainfo.path = $$PREFIX/share/metainfo/
+   metainfo.files += res/io.github.foldynl.QLog.metainfo.xml
+
+   INSTALLS += target desktop icon metainfo
 
    INCLUDEPATH += /usr/local/include
    LIBS += -L/usr/local/lib -lhamlib

--- a/res/io.github.foldynl.QLog.metainfo.xml
+++ b/res/io.github.foldynl.QLog.metainfo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.foldynl.QLog</id>
+  <launchable type="desktop-id">qlog.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>QLog</name>
+  <developer_name>Ladislav Foldyna</developer_name>
+  <summary>Amateur radio logbook</summary>
+  <description>
+    <p>
+      QLog is an Amateur Radio logging application for Linux, Windows and macOS. It is based on the Qt framework and uses SQLite as database backend.
+      QLog aims to be as simple as possible, but to provide everything the operator expects from the log to be. This log is not currently focused on contests.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Customizable GUI</li>
+      <li>Rig and rotator control via Hamlib</li>
+      <li>HamQTH and QRZ.com callbook integration</li>
+      <li>DX cluster integration</li>
+      <li>LoTW, eQSL, QRZ.com, Clublog, HRDLog.net, ON4KST Chat integration (eQSL includes QSL pictures download)</li>
+      <li>Secure Password Storage for all services with password or security token</li>
+      <li>Online and Offline map</li>
+      <li>Club Member lookup</li>
+      <li>CW Keyer Support - CWDaemon, FLDigi (all supported modes), Morse Over CAT, WinKey V2</li>
+      <li>Bandmap</li>
+      <li>CW Console</li>
+      <li>WSJT-X integration</li>
+      <li>Station Location Profile support</li>
+      <li>Various station statistics</li>
+      <li>Basic Awards support</li>
+      <li>Custom QSO Filters</li>
+      <li>NO ads, NO user tracking, NO hidden telemetry - simply free and open-source</li>
+      <li>SQLite backend</li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The QLog main window</caption>
+      <image type="source">https://foldynl.github.io/QLog/screens/qlog_main.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/foldynl/QLog</url>
+  <url type="bugtracker">https://github.com/foldynl/QLog/issues</url>
+  <url type="help">https://github.com/foldynl/QLog/wiki</url>
+  <url type="contact">https://github.com/foldynl</url>
+  <url type="vcs-browser">https://github.com/foldynl/QLog</url>
+  <url type="contribute">https://github.com/foldynl/QLog/blob/master/CONTRIBUTING.md</url>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
This Pull request adds the [AppStream](https://freedesktop.org/software/appstream/docs/) metadata file that I originally created for QLog [Flatpak](https://flatpak.org) that I am currently working on. AppStream is a widely-used standard nowadays on most Linux package distribution systems and package management GUIs, not a Flatpak-specific thing, and as such will also be useful here in upstream.

73 DE Daniel OK2VLK