### PR TITLE
Add installation to PREFIX on mac when set

### DIFF
--- a/QLog.pro
+++ b/QLog.pro
@@ -386,6 +386,12 @@ macx: {
    equals(QT_MAJOR_VERSION, 6): LIBS += -lqt6keychain
    equals(QT_MAJOR_VERSION, 5): LIBS += -lqt5keychain
    DISTFILES +=
+
+   # This allows the app to be shipped in a non-bundeled version
+   !isEmpty(PREFIX) {
+     target.path = $$PREFIX
+     INSTALLS += target
+   }
 }
 
 win32: {


### PR DESCRIPTION
This allows the app to be shipped in a non-bundeled version

We need this to ship the app on macOS with nix
