### PR TITLE
Fix for MacOS Layout Geometry Restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ compile_commands.json
 
 # QtCreator local machine specific files for imported projects
 *creator.user*
+.DS_Store
+/build

--- a/core/main.cpp
+++ b/core/main.cpp
@@ -562,6 +562,8 @@ int main(int argc, char* argv[])
     w.setWindowIcon(icon);
 
     w.show();
-
+#ifdef Q_OS_OSX
+    w.setLayoutGeometry();
+#endif
     return app.exec();
 }

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -42,6 +42,7 @@ public slots:
     void rotErrorHandler(const QString &error, const QString &errorDetail);
     void cwKeyerErrorHandler(const QString &error, const QString &errorDetail);
     void stationProfileChanged();
+    void setLayoutGeometry();
 
 private slots:
     void rigConnect();
@@ -75,7 +76,7 @@ private slots:
     void shortcutALTBackslash();
     void setManualContact(bool);
     void showEditLayout();
-    void setLayoutGeometry();
+
     void saveProfileLayoutGeometry();
     void setEquipmentKeepOptions(bool);
 


### PR DESCRIPTION
For MacOS the restore of the window geometry needs to occur after the window is shown.