### PR TITLE
Bug with Change for poll 420

### DIFF
--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -1706,6 +1706,8 @@ void NewContactWidget::saveExternalContact(QSqlRecord record)
 
     if ( savedCallsign.isEmpty() ) return;
 
+    changeCallsignManually(savedCallsign);
+
     QSqlTableModel model;
 
     model.setTable("contacts");
@@ -1758,6 +1760,10 @@ void NewContactWidget::saveExternalContact(QSqlRecord record)
         if ( record.value("darc_dok").toString().isEmpty()
              && !uiDynamic->dokEdit->text().isEmpty() )
             record.setValue("darc_dok", uiDynamic->dokEdit->text());
+
+        if ( record.value("pota_ref").toString().isEmpty()
+            && !uiDynamic->potaEdit->text().isEmpty())
+            record.setValue("pota_ref", uiDynamic->potaEdit->text());
 
         // information depending on QTH (Grid)
         const QString &savedGrid = record.value("gridsquare").toString();


### PR DESCRIPTION
When logging contacts it is not working as intended here.  I noticed that when I log a station in WSJT-X the Status wipes the callsign before the logged message goes through so the information is not there to save.  I'm not sure if this is the best way to address but it seems to work.  Not sure if it needs to be fixed a different way.

- I wanted to add where I could type in a Pota Reference in the New Log Entry and have it save but since it wipes it wouldn't work.  Not sure how it could be paused longer.  Unless maybe ignore WSJTX status messages with no callsign and only wipe if once it is logged?