### PR TITLE
UpdateRegEx

### DIFF
--- a/ui/WsjtxWidget.cpp
+++ b/ui/WsjtxWidget.cpp
@@ -21,7 +21,7 @@ MODULE_IDENTIFICATION("qlog.ui.wsjtxswidget");
 WsjtxWidget::WsjtxWidget(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::WsjtxWidget),
-    cqRE("^CQ (DX |TEST |[A-Z]{0,2} )?([A-Z0-9\\/]+) ?([A-Z]{2}[0-9]{2})?.*")
+    cqRE("(^(?:(?P<word1>(?:CQ|DE|QRZ)(?:\\s?DX|\\s(?:[A-Z]{1,4}|\\d{3}))|[A-Z0-9\\/]+|\\.{3})\\s)(?:(?P<word2>[A-Z0-9\\/]+)(?:\\s(?P<word3>[-+A-Z0-9]+)(?:\\s(?P<word4>(?:OOO|(?!RR73)[A-R]{2}[0-9]{2})))?)?)?)")
 {
     FCT_IDENTIFICATION;
 
@@ -64,8 +64,8 @@ void WsjtxWidget::decodeReceived(WsjtxDecode decode)
             WsjtxEntry entry;
 
             entry.decode = decode;
-            entry.callsign = match.captured(2);
-            entry.grid = match.captured(3);
+            entry.callsign = match.captured(3);
+            entry.grid = match.captured(4);
             entry.dxcc = Data::instance()->lookupDxcc(entry.callsign);
             entry.status = Data::instance()->dxccStatus(entry.dxcc.dxcc, currBand, BandPlan::MODE_GROUP_STRING_DIGITAL);
             entry.receivedTime = QDateTime::currentDateTimeUtc();


### PR DESCRIPTION
I've noticed a few times if people put like CQ POTA the callsign shows up as that way in the WSJTX Widget and subsequently the Alerts Widget.  This is a more detailed RegEx I found and tweaked to try and combat that.  Example below:
![Pasted Graphic 2](https://github.com/user-attachments/assets/4f2eb0e2-c98f-4228-9068-cc613567fd7c)
