### PR TITLE
UserFilter Export

### DIFF
--- a/logformat/LogFormat.cpp
+++ b/logformat/LogFormat.cpp
@@ -22,6 +22,7 @@ LogFormat::LogFormat(QTextStream& stream) :
 {
     FCT_IDENTIFICATION;
     this->defaults = nullptr;
+
 }
 
 LogFormat::~LogFormat() {
@@ -176,7 +177,61 @@ QString LogFormat::getWhereClause()
                                                   : "upper(qsl_sent_via) = upper(:qsl_sent_via)");
     }
 
+    if ( setFilterQSOFilter)
+    {
+        whereClause << ( getUserFilter() );
+    }
+
     return whereClause.join(" AND ");
+}
+
+QString LogFormat::getUserFilter()
+{
+    FCT_IDENTIFICATION;
+    QSettings settings;
+    QString QSOFilterString = settings.value("logbook/filters/user").toString();
+
+    QString UserFilter="";
+
+    if ( !QSOFilterString.isEmpty() )
+    {
+        QSqlQuery userFilterQuery;
+        if ( ! userFilterQuery.prepare("SELECT "
+                                     "'(' || GROUP_CONCAT( ' ' || c.name || ' ' || CASE WHEN r.value IS NULL AND o.sql_operator IN ('=', 'like') THEN 'IS' "
+                                     "                                                  WHEN r.value IS NULL and r.operator_id NOT IN ('=', 'like') THEN 'IS NOT' "
+                                     "                                                  WHEN o.sql_operator = ('starts with') THEN 'like' "
+                                     "                                                  ELSE o.sql_operator END || "
+                                     "' (' || quote(CASE o.sql_operator WHEN 'like' THEN '%' || r.value || '%' "
+                                     "                                  WHEN 'not like' THEN '%' || r.value || '%' "
+                                     "                                  WHEN 'starts with' THEN r.value || '%' "
+                                     "                                  ELSE r.value END)  || ') ', m.sql_operator) || ')' "
+                                     "FROM qso_filters f, qso_filter_rules r, "
+                                     "qso_filter_operators o, qso_filter_matching_types m, "
+                                     "PRAGMA_TABLE_INFO('contacts') c "
+                                     "WHERE f.filter_name = :filterName "
+                                     "      AND f.filter_name = r.filter_name "
+                                     "      AND o.operator_id = r.operator_id "
+                                     "      AND m.matching_id = f.matching_type "
+                                     "      AND c.cid = r.table_field_index") )
+        {
+            qWarning() << "Cannot prepare select statement";
+            return "";
+        }
+
+        userFilterQuery.bindValue(":filterName", QSOFilterString);
+
+        qCDebug(runtime) << "User filter SQL: " << userFilterQuery.lastQuery();
+
+        if ( userFilterQuery.exec() )
+        {
+            userFilterQuery.next();
+            UserFilter.append(QString("( ") + userFilterQuery.value(0).toString() + ")");
+        }
+        else
+            qCDebug(runtime) << "User filter error - " << userFilterQuery.lastError().text();
+    }
+    qWarning() << UserFilter;
+    return UserFilter;
 }
 
 void LogFormat::bindWhereClause(QSqlQuery &query)

--- a/logformat/LogFormat.h
+++ b/logformat/LogFormat.h
@@ -65,12 +65,13 @@ public:
     void setFilterMyGridsquare(const QString &myGridsquare);
     void setFilterSentPaperQSL(bool includeNo, bool includeIgnore, bool includeAlreadySent);
     void setFilterSendVia(const QString &value);
+    bool setFilterQSOFilter;
     QString getWhereClause();
     void bindWhereClause(QSqlQuery &);
     void setExportedFields(const QStringList& fieldsList);
     void setUpdateDxcc(bool updateDxcc);
     void setDuplicateQSOCallback(duplicateQSOBehaviour (*func)(QSqlRecord *, QSqlRecord *));
-
+    QString getUserFilter();
     virtual void importStart() {}
     virtual void importEnd() {}
     virtual bool importNext(QSqlRecord&) { return false; }

--- a/ui/ExportDialog.cpp
+++ b/ui/ExportDialog.cpp
@@ -165,6 +165,8 @@ void ExportDialog::runExport()
                                       (ui->addlSentStatusCheckbox->isChecked()) ? ui->addlSentStatusAlreadySentCheckBox->isChecked() : false);
     }
 
+    format->setFilterQSOFilter = ui->applyQSOFilterCheckbox->isChecked();
+
     long count = 0L;
 
     connect(format, &LogFormat::exportProgress, this, &ExportDialog::setProgress);
@@ -190,6 +192,7 @@ void ExportDialog::runExport()
     ui->qslSendViaComboBox->setEnabled(false);
     ui->markAsSentCheckbox->setEnabled(false);
     ui->exportedColumnsCombo->setEnabled(false);
+    ui->applyQSOFilterCheckbox->setEnabled(false);
 
     if ( exportedColumns.count() > 0 )
     {

--- a/ui/ExportDialog.ui
+++ b/ui/ExportDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>465</width>
-    <height>500</height>
+    <height>592</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLineEdit" name="fileEdit">
         <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
+         <enum>Qt::FocusPolicy::ClickFocus</enum>
         </property>
         <property name="readOnly">
          <bool>true</bool>
@@ -45,8 +45,7 @@
          <string>Browse</string>
         </property>
         <property name="icon">
-         <iconset theme="folder-open">
-          <normaloff>.</normaloff>.</iconset>
+         <iconset theme="folder-open"/>
         </property>
        </widget>
       </item>
@@ -210,7 +209,7 @@
            </sizepolicy>
           </property>
           <property name="focusPolicy">
-           <enum>Qt::ClickFocus</enum>
+           <enum>Qt::FocusPolicy::ClickFocus</enum>
           </property>
           <property name="toolTip">
            <string>Export only QSOs that match the selected date range</string>
@@ -232,7 +231,7 @@
            <string notr="true">-</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -248,7 +247,7 @@
            </sizepolicy>
           </property>
           <property name="focusPolicy">
-           <enum>Qt::ClickFocus</enum>
+           <enum>Qt::FocusPolicy::ClickFocus</enum>
           </property>
           <property name="toolTip">
            <string>Export only QSOs that match the selected date range</string>
@@ -261,7 +260,7 @@
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -333,7 +332,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QCheckBox" name="addlSentStatusCheckbox">
         <property name="toolTip">
          <string>Include unusual QSO Sent statuses</string>
@@ -343,7 +342,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <layout class="QHBoxLayout" name="sentStatusLayout">
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -443,6 +442,16 @@
         </item>
        </layout>
       </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="applyQSOFilterCheckbox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export only QSOs that match the selected user QSO Filter&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Apply QSO Filter to exported items</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -456,10 +465,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Since the 'Select All' option was removed I wanted a way to export items easily based on user filter.  I love the user filter options and I used it for like an export of FT8-FT4 QSOs to update my WSJTX/JTDX log or when I do POTA activations I have a filter to limit to QSOs for just that activation.  So I thought it would be nice to be able to export based on the current logbookwidget QSO Filter.