### PR TITLE
Adds expand&collapse button to qso field tab widget

### DIFF
--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -7,6 +7,8 @@
 #include <QSqlField>
 #include <QTimeZone>
 #include <QKeyEvent>
+#include <QToolButton>
+#include <QStackedWidget>
 
 #include "rig/Rig.h"
 #include "rig/macros.h"
@@ -181,6 +183,23 @@ NewContactWidget::NewContactWidget(QWidget *parent) :
     sigCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
     uiDynamic->sigEdit->setCompleter(sigCompleter);
 
+    // tab pane with QSO fields - expand & collapse
+    tabCollapseBtn = new QToolButton();
+    QIcon *toggleIcon = new QIcon();
+    toggleIcon->addPixmap(QPixmap(":/icons/baseline-play_down-24px.svg"), QIcon::Normal, QIcon::On);
+    toggleIcon->addPixmap(QPixmap(":/icons/baseline-play_arrow-24px.svg"), QIcon::Normal, QIcon::Off);
+    tabCollapseBtn->setIcon(*toggleIcon);
+    tabCollapseBtn->setCheckable(true);
+    tabCollapseBtn->setToolTip(tr("Expand/Collapse"));
+    ui->qsoTabs->setCornerWidget(tabCollapseBtn, Qt::TopLeftCorner);
+    connect(tabCollapseBtn, &QAbstractButton::toggled, this, &NewContactWidget::tabsExpandCollapse);
+    connect(ui->qsoTabs, &QTabWidget::tabBarClicked, this, [this](const int index)
+    {
+        // force expand if a tab is activated
+        tabCollapseBtn->setChecked(true);
+    });
+
+
     /**************/
     /* CONNECTs   */
     /**************/
@@ -325,7 +344,9 @@ void NewContactWidget::readWidgetSettings()
     setComboBaseData(ui->lotwQslSentBox, settings.value("newcontact/lotwqslsent", "Q").toString());
     setComboBaseData(ui->eQSLSentBox, settings.value("newcontact/eqslqslsent", "Q").toString());
     setComboBaseData(ui->qslSentViaBox, settings.value("newcontact/qslsentvia", "").toString());
-    ui->propagationModeEdit->setCurrentText(Data::instance()->propagationModeIDToText(settings.value("newcontact/propmode", QString()).toString()));
+    ui->propagationModeEdit->setCurrentText(Data::instance()->propagationModeIDToText(settings.value("newcontact/propmode", QString()).toString()));    
+    tabCollapseBtn->setChecked(settings.value("newcontact/tabsexpanded", "1").toBool());
+    tabsExpandCollapse();
 }
 
 void NewContactWidget::writeWidgetSetting()
@@ -342,6 +363,8 @@ void NewContactWidget::writeWidgetSetting()
     settings.setValue("newcontact/eqslqslsent", ui->lotwQslSentBox->itemData(ui->lotwQslSentBox->currentIndex()));
     settings.setValue("newcontact/qslsentvia", ui->qslSentViaBox->itemData(ui->qslSentViaBox->currentIndex()));
     settings.setValue("newcontact/propmode", Data::instance()->propagationModeTextToID(ui->propagationModeEdit->currentText()));
+    settings.setValue("newcontact/tabsexpanded", tabCollapseBtn->isChecked());
+
 }
 
 /* function read global setting, called when starting or when Setting is reloaded */
@@ -3255,6 +3278,19 @@ void NewContactWidget::changeCallsignManually(const QString &callsign, double fr
     stopContactTimer();
 }
 
+void NewContactWidget::tabsExpandCollapse()
+{
+    FCT_IDENTIFICATION;
+
+    QStackedWidget* stackedWidget = ui->qsoTabs->findChild<QStackedWidget*>();
+    stackedWidget->setVisible(tabCollapseBtn->isChecked());
+    int maxSize = 16777215; // default expand fully
+    if(!tabCollapseBtn->isChecked()) {
+        maxSize = ui->qsoTabs->tabBar()->sizeHint().height();
+    }
+    ui->qsoTabs->setMaximumHeight(maxSize);
+}
+
 NewContactDynamicWidgets::NewContactDynamicWidgets(bool allocateWidgets,
                                                    QWidget *parent) :
     parent(parent),
@@ -3550,3 +3586,4 @@ void NewContactDynamicWidgets::initializeWidgets(int DBIndexMapping,
 
     widgetMapping[DBIndexMapping] = widget;
 }
+

--- a/ui/NewContactWidget.h
+++ b/ui/NewContactWidget.h
@@ -10,6 +10,7 @@
 #include <QLineEdit>
 #include <QHash>
 #include <QFormLayout>
+#include <QToolButton>
 
 #include "data/DxSpot.h"
 #include "rig/Rig.h"
@@ -246,6 +247,7 @@ private slots:
     void antProfileComboChanged(const QString&);
     void webLookup();
     void refreshSIGCompleter();
+    void tabsExpandCollapse();
 
 private:
     void useFieldsFromPrevQSO(const QString &callsign,
@@ -326,6 +328,7 @@ private:
     QSqlQuery prevQSOBaseCallMatchQuery;
     bool isPrevQSOExactMatchQuery;
     bool isPrevQSOBaseCallMatchQuery;
+    QToolButton *tabCollapseBtn;
 };
 
 #endif // QLOG_UI_NEWCONTACTWIDGET_H


### PR DESCRIPTION
The user may customize which fields appear above the qso tabs with the custom layout profiles. If a user wants to provide more screen real-estate to the log history and focus on only the desired important qso fields he/she may collapse the tabs with this new button.

[Kapture 2024-11-04 at 18.55.24.webm](https://github.com/user-attachments/assets/3733b18a-f13a-48c5-9793-f555ccf913d5)
