### PR TITLE
Adds station county and operator callsign to the station and deps

### DIFF
--- a/core/Migration.h
+++ b/core/Migration.h
@@ -42,7 +42,7 @@ private:
     QString fixIntlField(QSqlQuery &query, const QString &columName, const QString &columnNameIntl);
     bool refreshUploadStatusTrigger();
 
-    static const int latestVersion = 29;
+    static const int latestVersion = 30;
 };
 
 #endif // QLOG_CORE_MIGRATION_H

--- a/data/StationProfile.cpp
+++ b/data/StationProfile.cpp
@@ -11,9 +11,9 @@ MODULE_IDENTIFICATION("qlog.data.stationprofile");
 QDataStream& operator<<(QDataStream& out, const StationProfile& v)
 {
     out << v.profileName << v.callsign << v.locator
-        << v.operatorName << v.qthName << v.iota
+        << v.operatorName << v.operatorCallsign << v.qthName << v.iota
         << v.sota << v.sig << v.sigInfo << v.vucc
-        << v.wwff << v.pota << v.ituz << v.cqz << v.dxcc << v.country;
+        << v.wwff << v.pota << v.ituz << v.cqz << v.dxcc << v.country << v.county;
     return out;
 }
 
@@ -23,6 +23,7 @@ QDataStream& operator>>(QDataStream& in, StationProfile& v)
     in >> v.callsign;
     in >> v.locator;
     in >> v.operatorName;
+    in >> v.operatorCallsign;
     in >> v.qthName;
     in >> v.iota;
     in >> v.sota;
@@ -35,6 +36,7 @@ QDataStream& operator>>(QDataStream& in, StationProfile& v)
     in >> v.cqz;
     in >> v.dxcc;
     in >> v.country;
+    in >> v.county;
 
     return in;
 }
@@ -51,7 +53,7 @@ StationProfilesManager::StationProfilesManager(QObject *parent) :
 
     if ( ! profileQuery.prepare("SELECT profile_name, callsign, locator, "
                                 "operator_name, qth_name, iota, sota, sig, sig_info, vucc, pota, "
-                                "ituz, cqz, dxcc, country "
+                                "ituz, cqz, dxcc, country, county, operator_callsign "
                                 "FROM station_profiles") )
     {
         qWarning()<< "Cannot prepare select";
@@ -77,6 +79,8 @@ StationProfilesManager::StationProfilesManager(QObject *parent) :
             profileDB.cqz = profileQuery.value(12).toInt();
             profileDB.dxcc = profileQuery.value(13).toInt();
             profileDB.country = profileQuery.value(14).toString();
+            profileDB.county = profileQuery.value(15).toString();
+            profileDB.operatorCallsign = profileQuery.value(16).toString();
 
             addProfile(profileDB.profileName, profileDB);
         }
@@ -101,8 +105,8 @@ void StationProfilesManager::save()
         return;
     }
 
-    if ( ! insertQuery.prepare("INSERT INTO station_profiles(profile_name, callsign, locator, operator_name, qth_name, iota, sota, sig, sig_info, vucc, wwff, pota, ituz, cqz, dxcc, country) "
-                        "VALUES (:profile_name, :callsign, :locator, :operator_name, :qth_name, :iota, :sota, :sig, :sig_info, :vucc, :wwff, :pota, :ituz, :cqz, :dxcc, :country)") )
+    if ( ! insertQuery.prepare("INSERT INTO station_profiles(profile_name, callsign, locator, operator_name, qth_name, iota, sota, sig, sig_info, vucc, wwff, pota, ituz, cqz, dxcc, country, county, operator_callsign) "
+                        "VALUES (:profile_name, :callsign, :locator, :operator_name, :qth_name, :iota, :sota, :sig, :sig_info, :vucc, :wwff, :pota, :ituz, :cqz, :dxcc, :country, :county, :operator_callsign)") )
     {
         qWarning() << "cannot prepare Insert statement";
         return;
@@ -131,6 +135,8 @@ void StationProfilesManager::save()
             insertQuery.bindValue(":cqz", stationProfile.cqz);
             insertQuery.bindValue(":dxcc", stationProfile.dxcc);
             insertQuery.bindValue(":country", stationProfile.country);
+            insertQuery.bindValue(":county", stationProfile.county);
+            insertQuery.bindValue(":operator_callsign", stationProfile.operatorCallsign);
 
             if ( ! insertQuery.exec() )
             {
@@ -163,7 +169,10 @@ bool StationProfile::operator==(const StationProfile &profile)
             && profile.ituz == this->ituz
             && profile.cqz == this->cqz
             && profile.dxcc == this->dxcc
-            && profile.country == this->country);
+            && profile.country == this->country
+            && profile.country == this->county
+            && profile.operatorCallsign == this->operatorCallsign
+            );
 }
 
 bool StationProfile::operator!=(const StationProfile &profile)
@@ -175,8 +184,11 @@ QString StationProfile::toHTMLString() const
 {
     QString ret = "<b>" + QObject::tr("Logging Station Callsign") + ":</b> " + callsign + "<br/>" +
                   ((!locator.isEmpty()) ? "<b>" + QObject::tr("My Gridsquare") + ":</b> " + locator + "<br/>" : "") +
-                  ((!operatorName.isEmpty()) ? "<b>" + QObject::tr("My Name") + ":</b> " + operatorName + "<br/>" : "") +
+                  ((!operatorName.isEmpty()) ? "<b>" + QObject::tr("Operator Name") + ":</b> " + operatorName + "<br/>" : "") +
+                  ((!operatorCallsign.isEmpty()) ? "<b>" + QObject::tr("Operator Callsign") + ":</b> " + operatorCallsign + "<br/>" : "") +
                   ((!qthName.isEmpty()) ? "<b>" + QObject::tr("My City") + ":</b> " + qthName + "<br/>" : "") +
+                  ((!country.isEmpty()) ? "<b>" + QObject::tr("My Country") + ":</b> " + country + "<br/>" : "") +
+                  ((!county.isEmpty()) ? "<b>" + QObject::tr("My County") + ":</b> " + county + "<br/>" : "") +
                   ((!iota.isEmpty()) ? "<b>" + QObject::tr("My IOTA") + ":</b> " + iota + "<br/>" : "") +
                   ((!sota.isEmpty()) ? "<b>" + QObject::tr("My SOTA") + ":</b> " + sota + "<br/>" : "" ) +
                   ((!sig.isEmpty()) ? "<b>" + QObject::tr("My Special Interest Activity") + ":</b> " + sig + "<br/>" : "" )+

--- a/data/StationProfile.h
+++ b/data/StationProfile.h
@@ -20,6 +20,7 @@ public:
     QString callsign;
     QString locator;
     QString operatorName;
+    QString operatorCallsign;
     QString qthName;
     QString iota;
     QString pota;
@@ -32,6 +33,7 @@ public:
     int cqz;
     int dxcc;
     QString country;
+    QString county;
 
     bool operator== (const StationProfile &profile);
     bool operator!= (const StationProfile &profile);

--- a/logformat/LogFormat.cpp
+++ b/logformat/LogFormat.cpp
@@ -287,6 +287,7 @@ unsigned long LogFormat::runImport(QTextStream& importLogStream,
         setIfEmpty(LogbookModel::COLUMN_STATION_CALLSIGN, defaultStationProfile->callsign);
         setIfEmpty(LogbookModel::COLUMN_MY_GRIDSQUARE, defaultStationProfile->locator);
         setIfEmpty(LogbookModel::COLUMN_MY_NAME, defaultStationProfile->operatorName);
+        setIfEmpty(LogbookModel::COLUMN_OPERATOR, defaultStationProfile->operatorCallsign);
         setIfEmpty(LogbookModel::COLUMN_MY_CITY_INTL, defaultStationProfile->qthName);
         setIfEmpty(LogbookModel::COLUMN_MY_CITY, Data::removeAccents(defaultStationProfile->qthName));
         setIfEmpty(LogbookModel::COLUMN_MY_IOTA, defaultStationProfile->iota);
@@ -301,6 +302,7 @@ unsigned long LogFormat::runImport(QTextStream& importLogStream,
         setIfEmpty(LogbookModel::COLUMN_MY_CQ_ZONE, QString::number(defaultStationProfile->cqz));
         setIfEmpty(LogbookModel::COLUMN_MY_COUNTRY_INTL, defaultStationProfile->country);
         setIfEmpty(LogbookModel::COLUMN_MY_COUNTRY, Data::removeAccents(defaultStationProfile->country));
+        setIfEmpty(LogbookModel::COLUMN_MY_CNTY, Data::removeAccents(defaultStationProfile->county));
     };
 
     auto setMyEntity = [&](const DxccEntity &myEntity)

--- a/res/res.qrc
+++ b/res/res.qrc
@@ -42,5 +42,6 @@
         <file>sql/migration_027.sql</file>
         <file>sql/migration_028.sql</file>
         <file>sql/migration_029.sql</file>
+        <file>sql/migration_030.sql</file>
     </qresource>
 </RCC>

--- a/res/sql/migration_030.sql
+++ b/res/sql/migration_030.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE station_profiles ADD county TEXT;
+ALTER TABLE station_profiles ADD operator_callsign TEXT;

--- a/ui/ColumnSettingDialog.cpp
+++ b/ui/ColumnSettingDialog.cpp
@@ -184,6 +184,7 @@ void ColumnSettingDialog::setupDialog()
         case LogbookModel::COLUMN_LON:
         case LogbookModel::COLUMN_OWNER_CALLSIGN:
         case LogbookModel::COLUMN_CONTACTED_OP:
+        case LogbookModel::COLUMN_OPERATOR:
         case LogbookModel::COLUMN_STATION_CALLSIGN:
         case LogbookModel::COLUMN_COMMENT:
         case LogbookModel::COLUMN_COUNTRY:

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -92,7 +92,7 @@ MainWindow::MainWindow(QWidget* parent) :
     conditionsLabel->setToolTip(QString("<img src='%1'>").arg(PropConditions::solarSummaryFile()));
     profileLabel = new QLabel("<b>" + profile.profileName + ":</b>", ui->statusBar);
     profileLabel->setIndent(10);
-    callsignLabel = new QLabel(profile.callsign.toLower() , ui->statusBar);
+    callsignLabel = new QLabel(stationCallsignStatus(profile), ui->statusBar);
     locatorLabel = new QLabel(profile.locator.toLower(), ui->statusBar);
     alertButton = new QPushButton("0", ui->statusBar);
     alertButton->setIcon(QIcon(":/icons/alert.svg"));
@@ -469,10 +469,17 @@ void MainWindow::stationProfileChanged()
     qCDebug(runtime) << profile.callsign << " " << profile.locator << " " << profile.operatorName;
 
     profileLabel->setText("<b>" + profile.profileName + ":</b>");
-    callsignLabel->setText(profile.callsign.toLower());
+    callsignLabel->setText(stationCallsignStatus(profile));
     locatorLabel->setText(profile.locator.toLower());
 
     emit settingsChanged();
+}
+
+QString MainWindow::stationCallsignStatus(const StationProfile &profile) {
+    if (profile.operatorCallsign.isEmpty() || profile.callsign == profile.operatorCallsign) {
+        return profile.callsign.toLower();
+    }
+    return profile.callsign.toLower() + " [op:" + profile.operatorCallsign.toLower() + "]";
 }
 
 void MainWindow::darkModeToggle(int mode)

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -106,6 +106,7 @@ private:
 
     void restoreUserDefinedShortcuts();
     void saveUserDefinedShortcuts();
+    QString stationCallsignStatus(const StationProfile &profile);
 };
 
 #endif // QLOG_UI_MAINWINDOW_H

--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -1178,6 +1178,21 @@ void NewContactWidget::addAddlFields(QSqlRecord &record, const StationProfile &p
         record.setValue("my_country_intl", profile.country);
     }
 
+    if ( record.value("my_cnty").toString().isEmpty()
+        && !profile.county.isEmpty() )
+    {
+        record.setValue("my_cnty", profile.county);
+    }
+
+    if ( record.value("operator").toString().isEmpty()
+        && !profile.operatorCallsign.isEmpty() )
+    {
+        record.setValue("operator", profile.operatorCallsign.toUpper());
+    } else if ( record.value("operator").toString().isEmpty()
+               && !profile.callsign.isEmpty() ) {
+        record.setValue("operator", profile.callsign.toUpper());
+    }
+
     if ( record.value("my_itu_zone").toString().isEmpty()
          && profile.ituz != 0 )
     {

--- a/ui/QSODetailDialog.cpp
+++ b/ui/QSODetailDialog.cpp
@@ -358,6 +358,8 @@ QSODetailDialog::QSODetailDialog(const QSqlRecord &qso,
     mapper->addMapping(ui->myVUCCEdit, LogbookModel::COLUMN_MY_VUCC_GRIDS);
     mapper->addMapping(ui->myWWFFEdit, LogbookModel::COLUMN_MY_WWFF_REF);
     mapper->addMapping(ui->powerEdit, LogbookModel::COLUMN_TX_POWER);
+    mapper->addMapping(ui->myCountyEdit, LogbookModel::COLUMN_MY_CNTY);
+    mapper->addMapping(ui->myOperatorCallsignEdit, LogbookModel::COLUMN_OPERATOR);
 
     /* Notes */
     mapper->addMapping(ui->noteEdit, LogbookModel::COLUMN_NOTES_INTL);
@@ -2160,6 +2162,7 @@ bool QSODetailDialog::LogbookModelPrivate::setData(const QModelIndex &index, con
            case COLUMN_MY_WWFF_REF:
            case COLUMN_WWFF_REF:
            case COLUMN_STATION_CALLSIGN:
+           case COLUMN_OPERATOR:
                main_update_result = QSqlTableModel::setData(index, ( !value.toString().isEmpty() ) ? value.toString().toUpper() // clazy:exclude=skipped-base-method
                                                                                                    : QVariant(), role);
                break;

--- a/ui/QSODetailDialog.ui
+++ b/ui/QSODetailDialog.ui
@@ -1292,92 +1292,17 @@
          <item row="1" column="1">
           <widget class="NewContactEditLine" name="myOperatorNameEdit"/>
          </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="myGridLabel">
-           <property name="text">
-            <string>Gridsquare</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="NewContactEditLine" name="myGridEdit"/>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="myQTHLabel">
-           <property name="text">
-            <string>QTH</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="NewContactEditLine" name="myQTHEdit"/>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="myRigLabel">
-           <property name="text">
-            <string>Rig</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="NewContactEditLine" name="myRigEdit"/>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="myAntLabel">
-           <property name="text">
-            <string>Antenna</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="NewContactEditLine" name="myAntEdit"/>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="powerLabel">
-           <property name="text">
-            <string>Power</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <widget class="QDoubleSpinBox" name="powerEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::StrongFocus</enum>
-           </property>
-           <property name="specialValueText">
-            <string>Blank</string>
-           </property>
-           <property name="suffix">
-            <string> W</string>
-           </property>
-           <property name="decimals">
-            <number>3</number>
-           </property>
-           <property name="maximum">
-            <double>1000000.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>0.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="myCountryLabel">
            <property name="text">
             <string>Country</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="QComboBox" name="myCountryCombo"/>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_15">
            <property name="spacing">
             <number>8</number>
@@ -1442,6 +1367,46 @@
             </spacer>
            </item>
           </layout>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="myGridLabel">
+           <property name="text">
+            <string>Gridsquare</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="NewContactEditLine" name="myGridEdit"/>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="myQTHLabel">
+           <property name="text">
+            <string>QTH</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="NewContactEditLine" name="myQTHEdit"/>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="myCountyLabel">
+           <property name="text">
+            <string>County</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="NewContactEditLine" name="myCountyEdit"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="myOperatorCallsignLabel">
+           <property name="text">
+            <string>Operator Callsign</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="NewContactEditLine" name="myOperatorCallsignEdit"/>
          </item>
         </layout>
        </item>
@@ -1526,17 +1491,66 @@
         </layout>
        </item>
        <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+        <layout class="QFormLayout" name="formLayout_6">
+         <property name="verticalSpacing">
+          <number>4</number>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
+         <item row="0" column="0">
+          <widget class="QLabel" name="myRigLabel">
+           <property name="text">
+            <string>Rig</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="NewContactEditLine" name="myRigEdit"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="myAntLabel">
+           <property name="text">
+            <string>Antenna</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="NewContactEditLine" name="myAntEdit"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="powerLabel">
+           <property name="text">
+            <string>Power</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QDoubleSpinBox" name="powerEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::FocusPolicy::StrongFocus</enum>
+           </property>
+           <property name="specialValueText">
+            <string>Blank</string>
+           </property>
+           <property name="suffix">
+            <string> W</string>
+           </property>
+           <property name="decimals">
+            <number>3</number>
+           </property>
+           <property name="maximum">
+            <double>1000000.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -2224,11 +2238,13 @@
   <tabstop>dxccTableWidget</tabstop>
   <tabstop>myCallsignEdit</tabstop>
   <tabstop>myOperatorNameEdit</tabstop>
+  <tabstop>myOperatorCallsignEdit</tabstop>
+  <tabstop>myCountryCombo</tabstop>
+  <tabstop>myITUEdit</tabstop>
+  <tabstop>myCQEdit</tabstop>
   <tabstop>myGridEdit</tabstop>
   <tabstop>myQTHEdit</tabstop>
-  <tabstop>myRigEdit</tabstop>
-  <tabstop>myAntEdit</tabstop>
-  <tabstop>powerEdit</tabstop>
+  <tabstop>myCountyEdit</tabstop>
   <tabstop>myIOTAEdit</tabstop>
   <tabstop>myPOTAEdit</tabstop>
   <tabstop>mySOTAEdit</tabstop>
@@ -2236,6 +2252,9 @@
   <tabstop>mySIGEdit</tabstop>
   <tabstop>mySIGInfoEdit</tabstop>
   <tabstop>myVUCCEdit</tabstop>
+  <tabstop>myRigEdit</tabstop>
+  <tabstop>myAntEdit</tabstop>
+  <tabstop>powerEdit</tabstop>
   <tabstop>qslPaperReceiveDateEdit</tabstop>
   <tabstop>qslPaperReceiveStatusBox</tabstop>
   <tabstop>qslPaperSentDateEdit</tabstop>

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -1555,6 +1555,7 @@ void SettingsDialog::addStationProfile()
     profile.callsign = ui->stationCallsignEdit->text().toUpper();
     profile.locator = ui->stationLocatorEdit->text().toUpper();
     profile.operatorName = ui->stationOperatorEdit->text();
+    profile.operatorCallsign = ui->stationOperatorCallsignEdit->text();
     profile.qthName = ui->stationQTHEdit->text();
     profile.iota = ui->stationIOTAEdit->text().toUpper();
     profile.sota = ui->stationSOTAEdit->text().toUpper();
@@ -1565,6 +1566,7 @@ void SettingsDialog::addStationProfile()
     profile.wwff = ui->stationWWFFEdit->text().toUpper();
     profile.cqz = ui->stationCQZEdit->text().toInt();
     profile.ituz = ui->stationITUEdit->text().toInt();
+    profile.county = ui->stationCountyEdit->text();
 
     int row = ui->stationCountryCombo->currentIndex();
     const QModelIndex &idxDXCC = ui->stationCountryCombo->model()->index(row,0);
@@ -1610,6 +1612,7 @@ void SettingsDialog::doubleClickStationProfile(QModelIndex i)
     ui->stationCallsignEdit->blockSignals(false);
     ui->stationLocatorEdit->setText(profile.locator);
     ui->stationOperatorEdit->setText(profile.operatorName);
+    ui->stationOperatorCallsignEdit->setText(profile.operatorCallsign);
     ui->stationQTHEdit->setText(profile.qthName);
     ui->stationIOTAEdit->setText(profile.iota);
     ui->stationSOTAEdit->blockSignals(true);
@@ -1626,6 +1629,7 @@ void SettingsDialog::doubleClickStationProfile(QModelIndex i)
     ui->stationWWFFEdit->blockSignals(false);
     ui->stationCQZEdit->setText(QString::number(profile.cqz));
     ui->stationITUEdit->setText(QString::number(profile.ituz));
+    ui->stationCountyEdit->setText(profile.county);
     const QModelIndexList &countryIndex = ui->stationCountryCombo->model()->match(ui->stationCountryCombo->model()->index(0,0),
                                                                            Qt::DisplayRole, profile.dxcc,
                                                                            1, Qt::MatchExactly);
@@ -1646,6 +1650,7 @@ void SettingsDialog::clearStationProfileForm()
     ui->stationLocatorEdit->clear();
     ui->stationLocatorEdit->setPlaceholderText(QString());
     ui->stationOperatorEdit->clear();
+    ui->stationOperatorCallsignEdit->clear();
     ui->stationQTHEdit->clear();
     ui->stationSOTAEdit->clear();
     ui->stationPOTAEdit->clear();
@@ -1657,6 +1662,7 @@ void SettingsDialog::clearStationProfileForm()
     ui->stationCQZEdit->clear();
     ui->stationITUEdit->clear();
     ui->stationCountryCombo->setCurrentIndex(0);
+    ui->stationCountyEdit->clear();
 
     ui->stationAddProfileButton->setText(tr("Add"));
 }

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -76,114 +76,17 @@
           <property name="verticalSpacing">
            <number>3</number>
           </property>
-          <item row="5" column="3">
-           <widget class="QLabel" name="stationLocatorLabel">
-            <property name="text">
-             <string>Gridsquare</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="2">
-           <widget class="QLineEdit" name="stationSOTAEdit">
-            <property name="toolTip">
-             <string>SOTA (Optional parameter)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
+          <item row="10" column="1">
            <widget class="QLabel" name="stationSOTALabel">
             <property name="text">
              <string>SOTA</string>
             </property>
-           </widget>
-          </item>
-          <item row="12" column="1" colspan="4">
-           <layout class="QHBoxLayout" name="horizontalLayout_12">
-            <item>
-             <widget class="QPushButton" name="stationAddProfileButton">
-              <property name="text">
-               <string>Add</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="stationDelProfileButton">
-              <property name="text">
-               <string>Delete</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="stationOperatorLabel">
-            <property name="text">
-             <string>Operator Name</string>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="3">
-           <widget class="QLabel" name="stationWWFFLabel">
-            <property name="text">
-             <string>WWFF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="4">
-           <widget class="QLineEdit" name="stationSIGEdit">
-            <property name="toolTip">
-             <string>SIG (Optional parameter).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2" colspan="3">
-           <widget class="QComboBox" name="stationCountryCombo"/>
-          </item>
-          <item row="10" column="4">
-           <widget class="QLineEdit" name="stationSIGInfoEdit">
-            <property name="toolTip">
-             <string>SIG Information (Optional parameter)</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLabel" name="stationQTHLabel">
-            <property name="text">
-             <string>QTH</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLineEdit" name="stationCallsignEdit">
-            <property name="toolTip">
-             <string>Callsign (Mandatory parameter)</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="maxLength">
-             <number>25</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" rowspan="13">
+          <item row="0" column="0" rowspan="15">
            <widget class="QListView" name="stationProfilesListView">
             <property name="focusPolicy">
              <enum>Qt::NoFocus</enum>
@@ -195,11 +98,21 @@
              <string>List of all available Station Profiles</string>
             </property>
             <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
+             <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
             </property>
            </widget>
           </item>
-          <item row="5" column="2">
+          <item row="12" column="3">
+           <widget class="QLabel" name="stationSIGInfoLabel">
+            <property name="text">
+             <string>SIG Info</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
            <layout class="QHBoxLayout" name="horizontalLayout_31">
             <property name="spacing">
              <number>6</number>
@@ -268,38 +181,120 @@
             </item>
            </layout>
           </item>
-          <item row="8" column="4">
-           <widget class="QLineEdit" name="stationWWFFEdit">
-            <property name="toolTip">
-             <string>World Wide Flora &amp; Fauna (Optional parameter)</string>
+          <item row="12" column="1">
+           <widget class="QLabel" name="stationIOTALabel">
+            <property name="text">
+             <string>IOTA</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Operator Callsign</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="stationOperatorLabel">
+            <property name="text">
+             <string>Operator Name</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="2">
+           <widget class="QLineEdit" name="stationPOTAEdit"/>
+          </item>
+          <item row="11" column="1">
+           <widget class="QLabel" name="stationPOTALabel">
+            <property name="text">
+             <string>POTA</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QLabel" name="stationQTHLabel">
+            <property name="text">
+             <string>QTH</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="3">
+           <widget class="QLabel" name="stationSIGLabel">
+            <property name="text">
+             <string>SIG</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Country</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="stationCallsignLabel">
+            <property name="text">
+             <string>Station Callsign</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2" colspan="3">
+           <widget class="QComboBox" name="stationCountryCombo"/>
+          </item>
+          <item row="4" column="1">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string/>
             </property>
            </widget>
           </item>
-          <item row="6" column="3">
+          <item row="0" column="1">
+           <widget class="QLabel" name="stationProfileNameLabel">
+            <property name="text">
+             <string>Profile Name</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
            <widget class="QLabel" name="stationVUCCLabel">
             <property name="text">
              <string>VUCC</string>
             </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Country</string>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="9" column="2">
-           <widget class="QLineEdit" name="stationPOTAEdit"/>
-          </item>
-          <item row="6" column="4">
+          <item row="8" column="4">
            <widget class="QLineEdit" name="stationVUCCEdit">
             <property name="toolTip">
              <string>VUCC  Grids (Optional parameter). Ex. EN98,FM08,EM97,FM07</string>
@@ -309,14 +304,14 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="2">
-           <widget class="QLineEdit" name="stationIOTAEdit">
+          <item row="8" column="2">
+           <widget class="QLineEdit" name="stationQTHEdit">
             <property name="toolTip">
-             <string>IOTA  (Optional parameter)</string>
+             <string>QTH Name (Optional parameter)</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="4">
+          <item row="7" column="4">
            <widget class="QLineEdit" name="stationLocatorEdit">
             <property name="toolTip">
              <string>Station Gridsquare (Mandatory parameter)</string>
@@ -329,52 +324,113 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="2">
-           <widget class="QLineEdit" name="stationQTHEdit">
+          <item row="12" column="4">
+           <widget class="QLineEdit" name="stationSIGInfoEdit">
             <property name="toolTip">
-             <string>QTH Name (Optional parameter)</string>
+             <string>SIG Information (Optional parameter)</string>
+            </property>
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
-           <widget class="QLabel" name="stationIOTALabel">
-            <property name="text">
-             <string>IOTA</string>
+          <item row="10" column="4">
+           <widget class="QLineEdit" name="stationWWFFEdit">
+            <property name="toolTip">
+             <string>World Wide Flora &amp; Fauna (Optional parameter)</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="stationCallsignLabel">
-            <property name="text">
-             <string>Callsign</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="3">
-           <widget class="QLabel" name="stationSIGLabel">
-            <property name="text">
-             <string>SIG</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1">
-           <widget class="QLabel" name="stationPOTALabel">
-            <property name="text">
-             <string>POTA</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="stationProfileNameLabel">
-            <property name="text">
-             <string>Profile Name</string>
-            </property>
-           </widget>
+          <item row="14" column="1" colspan="4">
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
+            <item>
+             <widget class="QPushButton" name="stationAddProfileButton">
+              <property name="text">
+               <string>Add</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="stationDelProfileButton">
+              <property name="text">
+               <string>Delete</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item row="10" column="3">
-           <widget class="QLabel" name="stationSIGInfoLabel">
+           <widget class="QLabel" name="stationWWFFLabel">
             <property name="text">
-             <string>SIG Info</string>
+             <string>WWFF</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="1">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLineEdit" name="stationCallsignEdit">
+            <property name="toolTip">
+             <string>Callsign (Mandatory parameter)</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="maxLength">
+             <number>25</number>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="4">
+           <widget class="QLineEdit" name="stationSIGEdit">
+            <property name="toolTip">
+             <string>SIG (Optional parameter).</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="2">
+           <widget class="QLineEdit" name="stationIOTAEdit">
+            <property name="toolTip">
+             <string>IOTA  (Optional parameter)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2" colspan="2">
+           <widget class="QLineEdit" name="stationOperatorEdit">
+            <property name="toolTip">
+             <string>Operator name (Optional parameter)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLineEdit" name="stationOperatorCallsignEdit">
+            <property name="toolTip">
+             <string>Callsign of operator (Optional parameter, if different from station callsign)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QLabel" name="stationLocatorLabel">
+            <property name="text">
+             <string>Gridsquare</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="2">
+           <widget class="QLineEdit" name="stationSOTAEdit">
+            <property name="toolTip">
+             <string>SOTA (Optional parameter)</string>
             </property>
            </widget>
           </item>
@@ -385,10 +441,27 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2" colspan="2">
-           <widget class="QLineEdit" name="stationOperatorEdit">
+          <item row="9" column="1">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLabel" name="stationCountyLabel">
+            <property name="text">
+             <string>County</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="2" colspan="2">
+           <widget class="QLineEdit" name="stationCountyEdit">
             <property name="toolTip">
-             <string>Operator name (Optional parameter)</string>
+             <string>Station County Location (Optional parameter)</string>
             </property>
            </widget>
           </item>
@@ -4066,7 +4139,9 @@
   <tabstop>stationProfileNameEdit</tabstop>
   <tabstop>stationCallsignEdit</tabstop>
   <tabstop>stationOperatorEdit</tabstop>
+  <tabstop>stationOperatorCallsignEdit</tabstop>
   <tabstop>stationCountryCombo</tabstop>
+  <tabstop>stationCountyEdit</tabstop>
   <tabstop>stationITUEdit</tabstop>
   <tabstop>stationCQZEdit</tabstop>
   <tabstop>stationLocatorEdit</tabstop>


### PR DESCRIPTION
Adds operator (callsign) (fixes #441) and my_cnty (station county) (fixes #493) to station info.

station config:
![Screenshot 2024-11-08 at 8 55 03 PM](https://github.com/user-attachments/assets/133d256d-762f-4954-a243-3b8180e6fbbb)

Explicit "different operator than station" status:
![Screenshot 2024-11-08 at 8 54 45 PM](https://github.com/user-attachments/assets/fc2e9083-0b3b-46f5-a058-1f114e14a7e4)

QSO fields, moved shack info to 3rd column:
![Screenshot 2024-11-08 at 8 54 37 PM](https://github.com/user-attachments/assets/f11feeb9-cd11-4e1c-a6a1-066c8e3d9773)


@foldynl If there are other changes necessary as far as station_callsign VERSUS operator (you mentioned "changing the logic in TSQL and other exports.") please let me know what needs to be updated. ADIF fields my_cnty and operator are exported correctly.