### PR TITLE
OS X: fix homebrew paths in project configuration

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -95,6 +95,7 @@ jobs:
      - name: Build dmg
        run: |
          cd build
+         install_name_tool -add_rpath $(brew --prefix qt)/lib qlog.app/Contents/MacOS/qlog
          macdeployqt qlog.app
          cp `brew --prefix`/lib/libhamlib.dylib qlog.app/Contents/Frameworks/libhamlib.dylib
          cp `brew --prefix`/lib/libqt6keychain.dylib qlog.app/Contents/Frameworks/libqt6keychain.dylib

--- a/.github/workflows/macOSBuild.yml
+++ b/.github/workflows/macOSBuild.yml
@@ -50,6 +50,7 @@ jobs:
          make -j4
      - name: Build dmg
        run: |
+         install_name_tool -add_rpath $(brew --prefix qt)/lib qlog.app
          cd build
          macdeployqt qlog.app -executable=./qlog.app/Contents/MacOS/qlog
          cp `brew --prefix`/lib/libhamlib.dylib qlog.app/Contents/Frameworks/libhamlib.dylib

--- a/QLog.pro
+++ b/QLog.pro
@@ -469,8 +469,15 @@ macx: {
       INSTALLS += target
    }
 
-   INCLUDEPATH += /usr/local/include /opt/homebrew/include
-   LIBS += -L/usr/local/lib -L/opt/homebrew/lib -lhamlib -lsqlite3
+   # If the host is Apple Silicon, Homebrew will likely be installed
+   # within /opt/homebrew path
+   isEqual($$system(uname -m), "arm64") {
+      INCLUDEPATH += /usr/local/include /opt/homebrew/include
+      LIBS += -L/usr/local/lib -L/opt/homebrew/lib -lhamlib -lsqlite3
+   } else {
+      INCLUDEPATH += /usr/local/include
+      LIBS += -L/usr/local/lib -lhamlib -lsqlite3
+   }
    equals(QT_MAJOR_VERSION, 6): LIBS += -lqt6keychain
    equals(QT_MAJOR_VERSION, 5): LIBS += -lqt5keychain
    DISTFILES +=


### PR DESCRIPTION
OS X: fix homebrew paths in project configuration
    
Apple Silicon and Intel-based Macs seem to have different paths where Homebrew can be installed. On Intel-based Macs it may lead to the following error:

ld: warning: search path '/opt/homebrew/lib' not found