### PR TITLE
Bandmap: add spotter to spot tooltip

### DIFF
--- a/ui/BandmapWidget.cpp
+++ b/ui/BandmapWidget.cpp
@@ -233,7 +233,9 @@ void BandmapWidget::updateStations()
         QString unit;
         unsigned char decP;
         double spotFreq = Data::MHz2UserFriendlyFreq(lower.key(), unit, decP);
-        text->setToolTip(QString("<b>%1</b><br/>%2 %3; %4<br/>%5").arg(callsignTmp,
+        const QString &spotterCallsign = lower.value().spotter;
+        text->setToolTip(QString("<b>%1</b> de %2<br/>%3 %4; %5<br/>%6").arg(callsignTmp,
+                                                             spotterCallsign,
                                                              QString::number(spotFreq, 'f', decP),
                                                              unit,
                                                              lower.value().modeGroupString,


### PR DESCRIPTION
Added the spotter's callsign to the tooltip you get when mousing over a spot on the bandmap.  It is often convenient to see if it's a local-ish station spotting it or someone across the globe.