### PR TITLE
POTA file export

### DIFF
--- a/QLog.pro
+++ b/QLog.pro
@@ -102,6 +102,7 @@ SOURCES += \
         logformat/CSVFormat.cpp \
         logformat/JsonFormat.cpp \
         logformat/LogFormat.cpp \
+        logformat/PotaAdiFormat.cpp \
         models/AlertTableModel.cpp \
         models/AwardsTableModel.cpp \
         models/DxccTableModel.cpp \
@@ -241,6 +242,7 @@ HEADERS += \
         logformat/CSVFormat.h \
         logformat/JsonFormat.h \
         logformat/LogFormat.h \
+        logformat/PotaAdiFormat.h \
         models/AlertTableModel.h \
         models/AwardsTableModel.h \
         models/DxccTableModel.h \

--- a/logformat/AdiFormat.cpp
+++ b/logformat/AdiFormat.cpp
@@ -13,7 +13,6 @@ void AdiFormat::exportStart()
 {
     FCT_IDENTIFICATION;
 
-    stream << "### QLog ADIF Export\n";
     writeField("ADIF_VER", ALWAYS_PRESENT, ADIF_VERSION_STRING);
     writeField("PROGRAMID", ALWAYS_PRESENT, PROGRAMID_STRING);
     writeField("PROGRAMVERSION", ALWAYS_PRESENT, VERSION);

--- a/logformat/LogFormat.cpp
+++ b/logformat/LogFormat.cpp
@@ -3,6 +3,7 @@
 #include "LogFormat.h"
 #include "AdiFormat.h"
 #include "AdxFormat.h"
+#include "PotaAdiFormat.h"
 #include "JsonFormat.h"
 #include "CSVFormat.h"
 #include "data/Data.h"
@@ -51,6 +52,9 @@ LogFormat* LogFormat::open(QString type, QTextStream& stream) {
     else if (type == "cabrillo") {
         return open(LogFormat::JSON, stream);
     }
+    else if (type == "pota") {
+        return open(LogFormat::POTA, stream);
+    }
     else {
         return nullptr;
     }
@@ -76,6 +80,9 @@ LogFormat* LogFormat::open(LogFormat::Type type, QTextStream& stream) {
 
     case LogFormat::CABRILLO:
         return nullptr;
+
+    case LogFormat::POTA:
+        return new PotaAdiFormat(stream);
 
     default:
         return nullptr;

--- a/logformat/LogFormat.h
+++ b/logformat/LogFormat.h
@@ -28,7 +28,8 @@ public:
         ADX,
         CABRILLO,
         JSON,
-        CSV
+        CSV,
+        POTA
     };
 
     enum QSLFrom {

--- a/logformat/PotaAdiFormat.cpp
+++ b/logformat/PotaAdiFormat.cpp
@@ -1,0 +1,139 @@
+#include "PotaAdiFormat.h"
+#include <QDebug>
+#include <QSqlField>
+#include <QSqlRecord>
+#include "core/debug.h"
+#include <models/LogbookModel.h>
+
+MODULE_IDENTIFICATION("qlog.logformat.potalogformat");
+
+#define ALWAYS_PRESENT true
+
+PotaAdiFormat::PotaAdiFormat(QTextStream &stream)
+    : AdiFormat(stream)
+    , currentDate(QDateTime::currentDateTime())
+{
+    FCT_IDENTIFICATION;
+}
+
+void PotaAdiFormat::setExportInfo(QFile &exportFile)
+{
+    this->exportInfo = new QFileInfo(exportFile);
+}
+
+void PotaAdiFormat::exportContact(const QSqlRecord &sourceRecord, QMap<QString, QString> *applTags)
+{
+    FCT_IDENTIFICATION;
+    if (this->exportInfo == nullptr) {
+        return;
+    }
+    // break single record into child activated park records
+    // assign records to files
+    QList<QSqlRecord> records = PotaAdiFormat::splitActivatedParks(sourceRecord);
+    for (QSqlRecord &record : records) {
+        duplicateField(record, "my_pota_ref", "my_sig");
+        record.field("my_sig").setValue(QString("POTA"));
+        duplicateField(record, "my_pota_ref", "my_sig_info");
+        if (!record.field("pota_ref").isNull()) {
+            duplicateField(record, "pota_ref", "sig_info");
+            duplicateField(record, "pota_ref", "sig");
+            record.field("sig").setValue(QString("POTA"));
+        }
+        AdiFormat *parkOut = this->getParkFile(record);
+        parkOut->exportContact(record, applTags);
+        // let parent do ADI export as normal to specified file
+        AdiFormat::exportContact(record, applTags);
+    }
+}
+
+AdiFormat *PotaAdiFormat::getParkFile(const QSqlRecord &record)
+{
+    // https://docs.pota.app/docs/activator_reference/logging_made_easy.html#naming-your-files
+    // station_callsign@park#-yyyymmdd
+    QString parkFileName(record.field("station_callsign").value().toString() + "@"
+                         + record.field("my_sig_info").value().toString() + "-"
+                         + currentDate.toString("yyyyMMdd-hhmm") + ".adif");
+
+    if (!parkFormats.contains(parkFileName)) {
+        parkFiles[parkFileName] = new QFile(exportInfo->canonicalPath() + QDir::separator()
+                                            + parkFileName);
+        if (!parkFiles[parkFileName]->open(QFile::WriteOnly | QFile::Text)) {
+            qCCritical(runtime) << "Could not open POTA park file for writing "
+                                << parkFiles[parkFileName]->fileName();
+        }
+        QTextStream *parkStream = new QTextStream(parkFiles[parkFileName]);
+        parkFormats[parkFileName] = new AdiFormat(*parkStream);
+        parkFormats[parkFileName]->exportStart();
+    }
+    qCDebug(runtime) << "using park file " << parkFileName << " is open? "
+                     << parkFiles[parkFileName]->isOpen();
+
+    return parkFormats[parkFileName];
+}
+
+QList<QSqlRecord> PotaAdiFormat::splitActivatedParks(const QSqlRecord &record)
+{
+    FCT_IDENTIFICATION;
+    // can contain multiple parks as a csv:
+    // <MY_POTA_REF:40>K-0817,K-4566,K-4576,K-4573,K-4578@US-WY
+    QStringList activatedParks = record.field("my_pota_ref")
+                                     .value()
+                                     .toString()
+                                     .split(QRegularExpression("\\s*,\\s*"),
+                                            Qt::SplitBehaviorFlags::SkipEmptyParts);
+
+    if (activatedParks.length() <= 0) {
+        return QList<QSqlRecord>();
+    } else if (activatedParks.length() == 1) {
+        return QList<QSqlRecord>({record});
+    } else {
+        QList<QSqlRecord> records = QList<QSqlRecord>();
+        for (const QString &parkID : activatedParks) {
+            QSqlRecord single = QSqlRecord(record);
+            single.setValue("my_pota_ref", parkID);
+
+            // If this is a park to park - the remote park can also be a multi park
+            // activation. These must also be split into multiple records.
+            QSqlField parkToPark = record.field("pota_ref");
+            if (parkToPark.isNull() || !parkToPark.value().toString().contains(",")) {
+                records.append(single);
+            } else {
+                QStringList remoteParks
+                    = parkToPark.value().toString().split(QRegularExpression("\\s*,\\s*"),
+                                                          Qt::SplitBehaviorFlags::SkipEmptyParts);
+                for (const QString &remoteParkID : remoteParks) {
+                    QSqlRecord remoteSingle = QSqlRecord(single);
+                    remoteSingle.setValue("pota_ref", remoteParkID);
+                    records.append(remoteSingle);
+                }
+            }
+        }
+        return records;
+    }
+}
+
+void PotaAdiFormat::exportEnd()
+{
+    for (AdiFormat *parkFormat : parkFormats.values()) {
+        parkFormat->exportEnd();
+    }
+}
+
+void PotaAdiFormat::duplicateField(QSqlRecord &record,
+                                   const QString &fromFieldName,
+                                   const QString &toFieldName)
+{
+    QSqlField dupped(record.field(fromFieldName));
+    record.remove(record.indexOf(toFieldName));
+    dupped.setName(toFieldName);
+    record.append(dupped);
+}
+
+PotaAdiFormat::~PotaAdiFormat()
+{
+    FCT_IDENTIFICATION;
+    qDeleteAll(parkFormats.values());
+    parkFormats.clear();
+    qDeleteAll(parkFiles.values());
+    parkFiles.clear();
+}

--- a/logformat/PotaAdiFormat.cpp
+++ b/logformat/PotaAdiFormat.cpp
@@ -79,8 +79,7 @@ QList<QSqlRecord> PotaAdiFormat::splitActivatedParks(const QSqlRecord &record)
     QStringList activatedParks = record.field("my_pota_ref")
                                      .value()
                                      .toString()
-                                     .split(QRegularExpression("\\s*,\\s*"),
-                                            Qt::SplitBehaviorFlags::SkipEmptyParts);
+                                     .split(QRegularExpression("\\s*,\\s*"), Qt::SkipEmptyParts);
 
     if (activatedParks.length() <= 0) {
         return QList<QSqlRecord>();
@@ -98,9 +97,9 @@ QList<QSqlRecord> PotaAdiFormat::splitActivatedParks(const QSqlRecord &record)
             if (parkToPark.isNull() || !parkToPark.value().toString().contains(",")) {
                 records.append(single);
             } else {
-                QStringList remoteParks
-                    = parkToPark.value().toString().split(QRegularExpression("\\s*,\\s*"),
-                                                          Qt::SplitBehaviorFlags::SkipEmptyParts);
+                QStringList remoteParks = parkToPark.value().toString().split(QRegularExpression(
+                                                                                  "\\s*,\\s*"),
+                                                                              Qt::SkipEmptyParts);
                 for (const QString &remoteParkID : remoteParks) {
                     QSqlRecord remoteSingle = QSqlRecord(single);
                     remoteSingle.setValue("pota_ref", remoteParkID);

--- a/logformat/PotaAdiFormat.cpp
+++ b/logformat/PotaAdiFormat.cpp
@@ -79,7 +79,8 @@ QList<QSqlRecord> PotaAdiFormat::splitActivatedParks(const QSqlRecord &record)
     QStringList activatedParks = record.field("my_pota_ref")
                                      .value()
                                      .toString()
-                                     .split(QRegularExpression("\\s*,\\s*"), Qt::SkipEmptyParts);
+                                     .split(QRegularExpression("\\s*,\\s*"),
+                                            Qt::SplitBehaviorFlags::SkipEmptyParts);
 
     if (activatedParks.length() <= 0) {
         return QList<QSqlRecord>();
@@ -97,9 +98,9 @@ QList<QSqlRecord> PotaAdiFormat::splitActivatedParks(const QSqlRecord &record)
             if (parkToPark.isNull() || !parkToPark.value().toString().contains(",")) {
                 records.append(single);
             } else {
-                QStringList remoteParks = parkToPark.value().toString().split(QRegularExpression(
-                                                                                  "\\s*,\\s*"),
-                                                                              Qt::SkipEmptyParts);
+                QStringList remoteParks
+                    = parkToPark.value().toString().split(QRegularExpression("\\s*,\\s*"),
+                                                          Qt::SplitBehaviorFlags::SkipEmptyParts);
                 for (const QString &remoteParkID : remoteParks) {
                     QSqlRecord remoteSingle = QSqlRecord(single);
                     remoteSingle.setValue("pota_ref", remoteParkID);

--- a/logformat/PotaAdiFormat.h
+++ b/logformat/PotaAdiFormat.h
@@ -1,0 +1,37 @@
+#ifndef QLOG_LOGFORMAT_POTALOGFORMAT_H
+#define QLOG_LOGFORMAT_POTALOGFORMAT_H
+#include "AdiFormat.h"
+
+/*
+ * A specialized case of ADI export, where each activated park gets T'd into its
+ * own file with some denormalization and values set to satisfy the pota.app
+ * upload processes.
+ */
+class PotaAdiFormat : public AdiFormat
+{
+public:
+    explicit PotaAdiFormat(QTextStream &stream);
+
+    virtual void exportContact(const QSqlRecord &,
+                               QMap<QString, QString> *applTags = nullptr) override;
+    virtual void exportEnd() override;
+
+    virtual bool importNext(QSqlRecord &) override { return false; }
+
+    void setExportInfo(QFile &exportFile);
+    ~PotaAdiFormat();
+
+    static QList<QSqlRecord> splitActivatedParks(const QSqlRecord &);
+
+private:
+    QFileInfo *exportInfo;
+    QMap<QString, AdiFormat *> parkFormats;
+    QMap<QString, QFile *> parkFiles;
+    QDateTime currentDate;
+    AdiFormat *getParkFile(const QSqlRecord &record);
+    static void duplicateField(QSqlRecord &record,
+                               const QString &fromFieldName,
+                               const QString &toFieldName);
+};
+
+#endif // QLOG_LOGFORMAT_POTALOGFORMAT_H

--- a/ui/ExportDialog.h
+++ b/ui/ExportDialog.h
@@ -38,7 +38,7 @@ public slots:
     void exportedColumnStateChanged(int index, bool state);
     void exportTypeChanged(int index);
     void exportedColumnsComboChanged(int);
-
+    void exportFormatChanged(const QString &format);
 private:
     Ui::ExportDialog *ui;
     LogLocale locale;
@@ -58,6 +58,23 @@ private:
         LogbookModel::COLUMN_SUBMODE,
         LogbookModel::COLUMN_RST_SENT,
         LogbookModel::COLUMN_RST_RCVD
+    };
+    const QSet<int> potaColumns{
+        LogbookModel::COLUMN_TIME_ON,
+        LogbookModel::COLUMN_CALL,
+        LogbookModel::COLUMN_OPERATOR,
+        LogbookModel::COLUMN_STATION_CALLSIGN,
+        LogbookModel::COLUMN_FREQUENCY,
+        LogbookModel::COLUMN_MODE,
+        LogbookModel::COLUMN_SUBMODE,
+        LogbookModel::COLUMN_MY_STATE,
+        LogbookModel::COLUMN_MY_COUNTRY,
+        LogbookModel::COLUMN_MY_POTA_REF,
+        LogbookModel::COLUMN_POTA_REF,
+        LogbookModel::COLUMN_MY_SIG,
+        LogbookModel::COLUMN_MY_SIG_INFO,
+        LogbookModel::COLUMN_SIG,
+        LogbookModel::COLUMN_SIG_INFO
     };
     LogbookModel logbookmodel;
     QSettings settings;

--- a/ui/ExportDialog.ui
+++ b/ui/ExportDialog.ui
@@ -32,7 +32,7 @@
       <item row="0" column="0">
        <widget class="QLineEdit" name="fileEdit">
         <property name="focusPolicy">
-         <enum>Qt::ClickFocus</enum>
+         <enum>Qt::FocusPolicy::ClickFocus</enum>
         </property>
         <property name="readOnly">
          <bool>true</bool>
@@ -76,6 +76,11 @@
         <item>
          <property name="text">
           <string>JSON</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>POTA</string>
          </property>
         </item>
        </widget>
@@ -210,7 +215,7 @@
            </sizepolicy>
           </property>
           <property name="focusPolicy">
-           <enum>Qt::ClickFocus</enum>
+           <enum>Qt::FocusPolicy::ClickFocus</enum>
           </property>
           <property name="toolTip">
            <string>Export only QSOs that match the selected date range</string>
@@ -232,7 +237,7 @@
            <string notr="true">-</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -248,7 +253,7 @@
            </sizepolicy>
           </property>
           <property name="focusPolicy">
-           <enum>Qt::ClickFocus</enum>
+           <enum>Qt::FocusPolicy::ClickFocus</enum>
           </property>
           <property name="toolTip">
            <string>Export only QSOs that match the selected date range</string>
@@ -261,7 +266,7 @@
         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -473,10 +478,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -713,6 +718,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>typeSelect</sender>
+   <signal>currentTextChanged(QString)</signal>
+   <receiver>ExportDialog</receiver>
+   <slot>exportFormatChanged(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>46</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>232</x>
+     <y>290</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>toggleDateRange()</slot>
@@ -721,6 +742,7 @@
   <slot>toggleMyCallsign()</slot>
   <slot>toggleMyGridsquare()</slot>
   <slot>myCallsignChanged(QString)</slot>
+  <slot>exportFormatChanged(QString)</slot>
   <slot>showColumnsSetting()</slot>
   <slot>toggleQslSendVia()</slot>
   <slot>exportTypeChanged(int)</slot>


### PR DESCRIPTION
This enhancement completes our pota user experience. I've explained the pota experience and common workflow as a wiki entry here:
https://github.com/kyleboyle/QLog/wiki/POTA-Activations

This PR is the missing functionality of the file export. There are various legacy and pota.app requirements which differentiates it from a generic adif export which I won't outline here but I describe briefly in the wiki and the full documentation is here:

https://docs.pota.app/docs/activator_reference/ADIF_for_POTA_reference.html

