### PR TITLE
Fix fieldNameTranslationMap - QSO Filters

### DIFF
--- a/models/LogbookModel.cpp
+++ b/models/LogbookModel.cpp
@@ -577,7 +577,7 @@ bool LogbookModel::setData(const QModelIndex &index, const QVariant &value, int 
     return main_update_result && depend_update_result;
 }
 
-QHash<LogbookModel::ColumnID, const char *> LogbookModel::fieldNameTranslationMap =
+QMap<LogbookModel::ColumnID, const char *> LogbookModel::fieldNameTranslationMap =
 {
     {COLUMN_ID, QT_TR_NOOP("QSO ID")},
     {COLUMN_TIME_ON, QT_TR_NOOP("Time on")},

--- a/models/LogbookModel.h
+++ b/models/LogbookModel.h
@@ -188,7 +188,7 @@ public:
     };
 
 private:
-    static QHash<LogbookModel::ColumnID, const char *> fieldNameTranslationMap;
+    static QMap<LogbookModel::ColumnID, const char *> fieldNameTranslationMap;
 
 public:
     static QString getFieldNameTranslation(const LogbookModel::ColumnID key)


### PR DESCRIPTION
Need to switch from qHash to qMap for QSO Filters to work properly. Existing filters would work unless they were modified, new one's would not work properly.