### PR TITLE
adds sorting function to logbook table columns

### DIFF
--- a/ui/LogbookWidget.cpp
+++ b/ui/LogbookWidget.cpp
@@ -161,7 +161,7 @@ LogbookWidget::LogbookWidget(QWidget *parent) :
         ui->contactTable->showColumn(LogbookModel::COLUMN_QTH_INTL);
         ui->contactTable->showColumn(LogbookModel::COLUMN_COMMENT_INTL);
     }
-
+    ui->contactTable->setSortingEnabled(true);
     ui->contactTable->horizontalHeader()->setSectionsMovable(true);
     ui->contactTable->setStyle(new ProxyStyle(ui->contactTable->style()));
     ui->contactTable->installEventFilter(this);


### PR DESCRIPTION
It looks like the qsqltablemodel will correctly handle the column sorting for us. Since you know the codebase better than I please let me know if the sorting feature will break something else and I can look at it.

![Screenshot 2024-12-03 at 2 45 09 PM](https://github.com/user-attachments/assets/1fd2e489-bcf7-437c-b475-6b02c2c8018d)



14:41:07.976 [DEBUG   ] [0x200a24f40]                    [qlog.ui.logbookwidget.runtime] => "SELECT \"id\", \"start_time\", \"end_time\", \"callsign\", \"rst_sent\", \"rst_rcvd\", \"freq\", \"band\", \"mode\", \"submode\", \"name\", \"qth\", \"gridsquare\", \"dxcc\", \"country\", \"cont\", \"cqz\", \"ituz\", \"pfx\", \"state\", \"cnty\", \"iota\", \"qsl_rcvd\", \"qsl_rdate\", \"qsl_sent\", \"qsl_sdate\", \"lotw_qsl_rcvd\", \"lotw_qslrdate\", \"lotw_qsl_sent\", \"lotw_qslsdate\", \"tx_pwr\", \"fields\", \"address\", \"address_intl\", \"age\", \"a_index\", \"ant_az\", \"ant_el\", \"ant_path\", \"arrl_sect\", \"award_submitted\", \"award_granted\", \"band_rx\", \"check\", \"class\", \"clublog_qso_upload_date\", \"clublog_qso_upload_status\", \"comment\", \"comment_intl\", \"contacted_op\", \"contest_id\", \"country_intl\", \"credit_submitted\", \"credit_granted\", \"darc_dok\", \"distance\", \"email\", \"eq_call\", \"eqsl_qslrdate\", \"eqsl_qslsdate\", \"eqsl_qsl_rcvd\", \"eqsl_qsl_sent\", \"fists\", \"fists_cc\", \"force_init\", \"freq_rx\", \"guest_op\", \"hrdlog_qso_upload_date\", \"hrdlog_qso_upload_status\", \"iota_island_id\", \"k_index\", \"lat\", \"lon\", \"max_bursts\", \"ms_shower\", \"my_antenna\", \"my_antenna_intl\", \"my_city\", \"my_city_intl\", \"my_cnty\", \"my_country\", \"my_country_intl\", \"my_cq_zone\", \"my_dxcc\", \"my_fists\", \"my_gridsquare\", \"my_iota\", \"my_iota_island_id\", \"my_itu_zone\", \"my_lat\", \"my_lon\", \"my_name\", \"my_name_intl\", \"my_postal_code\", \"my_postal_code_intl\", \"my_rig\", \"my_rig_intl\", \"my_sig\", \"my_sig_intl\", \"my_sig_info\", \"my_sig_info_intl\", \"my_sota_ref\", \"my_state\", \"my_street\", \"my_street_intl\", \"my_usaca_counties\", \"my_vucc_grids\", \"name_intl\", \"notes\", \"notes_intl\", \"nr_bursts\", \"nr_pings\", \"operator\", \"owner_callsign\", \"precedence\", \"prop_mode\", \"public_key\", \"qrzcom_qso_upload_date\", \"qrzcom_qso_upload_status\", \"qslmsg\", \"qslmsg_intl\", \"qsl_rcvd_via\", \"qsl_sent_via\", \"qsl_via\", \"qso_complete\", \"qso_random\", \"qth_intl\", \"region\", \"rig\", \"rig_intl\", \"rx_pwr\", \"sat_mode\", \"sat_name\", \"sfi\", \"sig\", \"sig_intl\", \"sig_info\", \"sig_info_intl\", \"silent_key\", \"skcc\", \"sota_ref\", \"srx\", \"srx_string\", \"station_callsign\", \"stx\", \"stx_string\", \"swl\", \"ten_ten\", \"uksmg\", \"usaca_counties\", \"ve_prov\", \"vucc_grids\", \"web\", \"my_arrl_sect\", \"my_wwff_ref\", \"wwff_ref\", \"altitude\", \"gridsquare_ext\", \"hamlogeu_qso_upload_date\", \"hamlogeu_qso_upload_status\", \"hamqth_qso_upload_date\", \"hamqth_qso_upload_status\", \"my_altitude\", \"my_gridsquare_ext\", \"my_pota_ref\", \"pota_ref\" FROM \"contacts\" WHERE mode = 'CW' **ORDER BY \"contacts\".\"callsign\" ASC"** [void LogbookWidget::filterTable():../../ui/LogbookWidget.cpp:953]  