### PR TITLE
Callbook Info

### DIFF
--- a/ui/LogbookWidget.h
+++ b/ui/LogbookWidget.h
@@ -5,6 +5,8 @@
 #include <QProxyStyle>
 #include <QComboBox>
 #include "models/SqlListModel.h"
+#include "core/CallbookManager.h"
+#include <QSqlRecord>
 
 namespace Ui {
 class LogbookWidget;
@@ -65,6 +67,13 @@ public slots:
     void focusSearchCallsign();
     void reloadSetting();
     void sendDXCSpot();
+    void actionCallbookLookup();
+    void callsignFound(const QMap<QString, QString>& data);
+    void callsignNotFound(const QString&);
+    void callbookLoginFailed(const QString&);
+    void callbookError(const QString&);
+    void updateQSOsCallbook(QList<QSqlRecord> qsos);
+    void updateQSOCallbook(QSqlRecord qso);
 
 private:
     ClubLog* clublog;
@@ -91,6 +100,10 @@ private:
     void reselectModel();
     void scrollToIndex(const QModelIndex& index, bool select = true);
     void adjusteComboMinSize(QComboBox * combo);
+    void UpdateQSORecordFromCallbook(QSqlRecord qso, const QMap<QString, QString>& data);
+    QList<QSqlRecord> TempQSOsCallbookLookup;
+    QSqlRecord TempQSOCallbookLookup;
+    CallbookManager callbookManager;
 };
 
 /* https://forum.qt.io/topic/90403/show-tooltip-immediatly/7/ */

--- a/ui/LogbookWidget.ui
+++ b/ui/LogbookWidget.ui
@@ -273,7 +273,7 @@
   <action name="actionCallbookLookup">
    <property name="icon">
     <iconset resource="../res/icons/icons.qrc">
-     <normaloff>:/icons/baseline-search-24px.svg</normaloff>:/icons/baseline-search-24px.svg</iconset>
+     <normaloff>:/icons/cloud_download-24px.svg</normaloff>:/icons/cloud_download-24px.svg</iconset>
    </property>
    <property name="text">
     <string>Add Missing Callbook Info</string>

--- a/ui/LogbookWidget.ui
+++ b/ui/LogbookWidget.ui
@@ -270,6 +270,18 @@
     <string>Lookup on Web</string>
    </property>
   </action>
+  <action name="actionCallbookLookup">
+   <property name="icon">
+    <iconset resource="../res/icons/icons.qrc">
+     <normaloff>:/icons/baseline-search-24px.svg</normaloff>:/icons/baseline-search-24px.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Add Missing Callbook Info</string>
+   </property>
+   <property name="toolTip">
+    <string>Add Missing Callbook Info</string>
+   </property>
+  </action>
   <action name="actionFilter">
    <property name="icon">
     <iconset resource="../res/icons/icons.qrc">
@@ -412,6 +424,22 @@
    <signal>triggered()</signal>
    <receiver>LogbookWidget</receiver>
    <slot>lookupSelectedCallsign()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>404</x>
+     <y>168</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionCallbookLookup</sender>
+   <signal>triggered()</signal>
+   <receiver>LogbookWidget</receiver>
+   <slot>actionCallbookLookup()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>
@@ -575,6 +603,7 @@
   <slot>uploadClublog()</slot>
   <slot>filterSelectedCallsign()</slot>
   <slot>lookupSelectedCallsign()</slot>
+  <slot>actionCallbookLookup()</slot>
   <slot>modeFilterChanged()</slot>
   <slot>countryFilterChanged()</slot>
   <slot>editContact()</slot>


### PR DESCRIPTION
Added a context menu item to the logbook widget to to allow for selected entries to fill missing information from online callbook source.  It will not overwrite information that is there, just append any missing information.  I am mostly interested in Email address and Name but figured I would add more information that others may find usefull.  It is written to limit to 100 updates at a time.

<img width="328" alt="image" src="https://github.com/user-attachments/assets/b0dc1a44-a38d-4012-a6f2-cd7f0e493eb1" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/0cb68e50-473a-49a2-bbad-62191e924c7d" />
