### PR TITLE
MacOS floating utility window bug

### DIFF
--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -91,6 +91,12 @@ MainWindow::MainWindow(QWidget* parent) :
     ui->onlineMapWidget->registerContactWidget(ui->newContactWidget);
     ui->chatWidget->registerContactWidget(ui->newContactWidget);
 
+    const QList<QDockWidget *> dockWidgets = findChildren<QDockWidget *>();
+    for (QDockWidget *dockWidget : dockWidgets) {
+        if (dockWidget)
+            dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
+    }
+
     setLayoutGeometry();
 
     const StationProfile &profile = StationProfilesManager::instance()->getCurProfile1();
@@ -399,14 +405,6 @@ MainWindow::MainWindow(QWidget* parent) :
     //restoreConnectionStates();
 
     setupActivitiesMenu();
-
-    const QList<QDockWidget*> dockWidgets = findChildren<QDockWidget*>();
-
-    for ( QDockWidget* dockWidget : dockWidgets )
-    {
-        if ( dockWidget )
-            dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
-    }
 }
 
 void MainWindow::closeEvent(QCloseEvent* event)


### PR DESCRIPTION
It appears order matters on app start for floating windows affected by restoreState. The report was that the floating windows were disappearing on app blur. This was happening when the floating windows were restored as floating windows from a restoreState call on app launch. New floating windows created during the app run time worked as expected.

I don't know why this works this way, some idiosyncrasy with QT I suppose. I narrowed it down to an interaction of this attribute with restoreState and tried setting the attribute before restoreState and it started working in all cases.