### PR TITLE
Add developer tag to AppStream metadata

### DIFF
--- a/res/io.github.foldynl.QLog.metainfo.xml
+++ b/res/io.github.foldynl.QLog.metainfo.xml
@@ -6,6 +6,9 @@
   <project_license>GPL-3.0-or-later</project_license>
   <name>QLog</name>
   <developer_name>Ladislav Foldyna</developer_name>
+  <developer id="io.github.foldynl">
+    <name>Ladislav Foldyna</name>
+  </developer>
   <summary>Amateur radio logbook</summary>
   <description>
     <p>


### PR DESCRIPTION
To make the metadata compatible with future AppStream standard version that uses the [developer tag](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer) instead of developer_name, but keep the original one for compatibility purposes.

@foldynl Feel free to review and merge. :-)