### PR TITLE
Multiple independent bandmap windows

### DIFF
--- a/.github/workflows/macOSBuild.yml
+++ b/.github/workflows/macOSBuild.yml
@@ -13,7 +13,7 @@ jobs:
      name: MacOS Build
      strategy:
        matrix:
-         os: [macos-12, macos-13]
+         os: [macos-12, macos-14]
 
      runs-on: ${{ matrix.os }}
 

--- a/core/main.cpp
+++ b/core/main.cpp
@@ -519,7 +519,7 @@ int main(int argc, char* argv[])
     QIcon icon(":/res/qlog.png");
     splash.finish(&w);
     w.setWindowIcon(icon);
-
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, &w, &MainWindow::aboutToQuit);
     w.show();
 #ifdef Q_OS_OSX
     w.setLayoutGeometry();

--- a/ui/BandmapWidget.cpp
+++ b/ui/BandmapWidget.cpp
@@ -841,7 +841,7 @@ void BandmapWidget::showContextMenu(const QPoint &point)
     for ( const Band &enabledBand : BandPlan::bandsList(false, true))
     {
         QAction* action = new QAction(enabledBand.name);
-        connect(action, &QAction::triggered, this, [this, enabledBand, action]() {
+        connect(action, &QAction::triggered, this, [this, enabledBand]() {
             setBand(enabledBand);
             update();
         });

--- a/ui/BandmapWidget.cpp
+++ b/ui/BandmapWidget.cpp
@@ -63,8 +63,6 @@ BandmapWidget::BandmapWidget(QWidget *parent, QString nonVfoWidgetId)
         qCDebug(runtime) << nonVfoWidgetId << "band from settings" << nonVfoBandName;
 
         for (const Band &enabledBand : BandPlan::bandsList(false, true)) {
-            qCDebug(runtime) << nonVfoWidgetId << "band from list" << enabledBand.name;
-
             if (enabledBand.name == nonVfoBandName) {
                 startingBand = enabledBand;
                 break;
@@ -843,11 +841,14 @@ void BandmapWidget::showContextMenu(const QPoint &point)
     for ( const Band &enabledBand : BandPlan::bandsList(false, true))
     {
         QAction* action = new QAction(enabledBand.name);
-        connect(action, &QAction::triggered, this, [this, enabledBand]()
-        {
+        connect(action, &QAction::triggered, this, [this, enabledBand, action]() {
             setBand(enabledBand);
             update();
         });
+        if (enabledBand == currentBand) {
+            action->setCheckable(true);
+            action->setChecked(true);
+        }
         bandsMenu.addAction(action);
     }
 
@@ -1130,12 +1131,6 @@ void BandmapWidget::clickNewBandmapWindow()
 Band *BandmapWidget::getBand()
 {
     return &currentBand;
-}
-
-void BandmapWidget::closeEvent(QCloseEvent *event)
-{
-    event->isInputEvent();
-    qCDebug(runtime) << "close event is input event " << event->isInputEvent();
 }
 
 void GraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *evt)

--- a/ui/BandmapWidget.h
+++ b/ui/BandmapWidget.h
@@ -41,7 +41,7 @@ class BandmapWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit BandmapWidget(QWidget *parent = nullptr);
+    explicit BandmapWidget(QWidget *parent = nullptr, QString nonVfoWidgetId = nullptr);
     ~BandmapWidget();
 
     enum BandmapZoom {
@@ -54,6 +54,7 @@ public:
         ZOOM_10KHZ
     };
 
+    Band *getBand();
 public slots:
     void update();
     void updateTunedFrequency(VFOID, double, double, double);
@@ -71,15 +72,18 @@ public slots:
     void recalculateDxccStatus();
     void resetDupe();
     void recalculateDupe();
+    void clickNewBandmapWindow();
+    void updateStations();
 
 signals:
     void tuneDx(DxSpot);
     void nearestSpotFound(const DxSpot &);
+    void requestNewNonVfoBandmapWindow();
+    void spotsUpdated();
 
 private:
     void removeDuplicates(DxSpot &spot);
     void spotAging();
-    void updateStations();
     void determineStepDigits(double &steps, int &digits) const;
     void clearAllCallsignFromScene();
     void clearFreqMark(QGraphicsPolygonItem **);
@@ -99,6 +103,7 @@ private:
     void saveCurrentScrollFreq();
     double getSavedScrollFreq(Band);
     double visibleCentreFreq() const;
+    void updateTunedFrequencyNonVfo(VFOID, double, double, double);
 
 private slots:
     void centerRXActionChecked(bool);
@@ -106,6 +111,9 @@ private slots:
     void showContextMenu(const QPoint&);
     void updateStationTimer();
     void focusZoomFreq(int, int);
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
 
 private:
     Ui::BandmapWidget *ui;
@@ -115,7 +123,6 @@ private:
     Band currentBand;
     BandmapZoom zoom;
     GraphicsScene* bandmapScene;
-    QMap<double, DxSpot> spots;
     QTimer *update_timer;
     QList<QGraphicsLineItem *> lineItemList;
     QList<QGraphicsTextItem *> textItemList;
@@ -138,6 +145,8 @@ private:
     };
     LastTuneDx lastTunedDX;
     DxSpot lastNearestSpot;
+    bool isNonVfo;
+    static QMap<double, DxSpot> spots;
 };
 
 Q_DECLARE_METATYPE(BandmapWidget::BandmapZoom)

--- a/ui/BandmapWidget.h
+++ b/ui/BandmapWidget.h
@@ -112,9 +112,6 @@ private slots:
     void updateStationTimer();
     void focusZoomFreq(int, int);
 
-protected:
-    void closeEvent(QCloseEvent *event) override;
-
 private:
     Ui::BandmapWidget *ui;
 

--- a/ui/BandmapWidget.ui
+++ b/ui/BandmapWidget.ui
@@ -35,13 +35,13 @@
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="focusPolicy">
-      <enum>Qt::ClickFocus</enum>
+      <enum>Qt::FocusPolicy::ClickFocus</enum>
      </property>
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
+      <enum>QFrame::Shadow::Plain</enum>
      </property>
      <property name="midLineWidth">
       <number>-3</number>
@@ -55,7 +55,7 @@
         <x>0</x>
         <y>0</y>
         <width>451</width>
-        <height>595</height>
+        <height>577</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -89,25 +89,25 @@
           </sizepolicy>
          </property>
          <property name="focusPolicy">
-          <enum>Qt::ClickFocus</enum>
+          <enum>Qt::FocusPolicy::ClickFocus</enum>
          </property>
          <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
+          <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
          </property>
          <property name="styleSheet">
           <string notr="true">QWidget{background: transparent}</string>
          </property>
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="verticalScrollBarPolicy">
-          <enum>Qt::ScrollBarAsNeeded</enum>
+          <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
          </property>
          <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAsNeeded</enum>
+          <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
          </property>
          <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustIgnored</enum>
+          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
          </property>
         </widget>
        </item>
@@ -120,7 +120,7 @@
      <item>
       <widget class="QPushButton" name="clearButton">
        <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
+        <enum>Qt::FocusPolicy::ClickFocus</enum>
        </property>
        <property name="text">
         <string>Clear All</string>
@@ -130,7 +130,7 @@
      <item>
       <widget class="QPushButton" name="zoomInButton">
        <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
+        <enum>Qt::FocusPolicy::ClickFocus</enum>
        </property>
        <property name="text">
         <string>In</string>
@@ -144,7 +144,7 @@
      <item>
       <widget class="QPushButton" name="zoomOutButton">
        <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
+        <enum>Qt::FocusPolicy::ClickFocus</enum>
        </property>
        <property name="text">
         <string>Out</string>
@@ -158,47 +158,101 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="clearSpotOlderLabel">
-       <property name="text">
-        <string>Clear older than</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="clearSpotOlderSpin">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="specialValueText">
-        <string>Never</string>
-       </property>
-       <property name="suffix">
-        <string> min(s)</string>
-       </property>
-       <property name="maximum">
-        <number>9999</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QWidget" name="bottomRow" native="true">
+     <layout class="QHBoxLayout" name="layoutBottomRow">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="clearSpotOlderLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Clear older than</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="clearSpotOlderSpin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::FocusPolicy::ClickFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="specialValueText">
+         <string>Never</string>
+        </property>
+        <property name="suffix">
+         <string> min(s)</string>
+        </property>
+        <property name="maximum">
+         <number>9999</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>100</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnNewBandmap">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>30</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Create an additional user-controlled Bandmap Window</string>
+        </property>
+        <property name="text">
+         <string comment="Create an additional user-controlled Bandmap Window">+</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -213,8 +267,8 @@
    <slot>clearSpots()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>149</x>
-     <y>617</y>
+     <x>140</x>
+     <y>613</y>
     </hint>
     <hint type="destinationlabel">
      <x>155</x>
@@ -229,8 +283,8 @@
    <slot>zoomIn()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>294</x>
-     <y>617</y>
+     <x>295</x>
+     <y>613</y>
     </hint>
     <hint type="destinationlabel">
      <x>155</x>
@@ -245,28 +299,12 @@
    <slot>zoomOut()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>440</x>
-     <y>617</y>
+     <x>449</x>
+     <y>613</y>
     </hint>
     <hint type="destinationlabel">
      <x>155</x>
      <y>281</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>clearSpotOlderSpin</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>BandmapWidget</receiver>
-   <slot>spotAgingChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>333</x>
-     <y>632</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>225</x>
-     <y>330</y>
     </hint>
    </hints>
   </connection>
@@ -286,6 +324,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>btnNewBandmap</sender>
+   <signal>clicked()</signal>
+   <receiver>BandmapWidget</receiver>
+   <slot>clickNewBandmapWindow()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>442</x>
+     <y>647</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>359</x>
+     <y>624</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>clearSpots()</slot>
@@ -293,5 +347,7 @@
   <slot>zoomOut()</slot>
   <slot>spotAgingChanged(int)</slot>
   <slot>showContextMenu(QPoint)</slot>
+  <slot>clickNewBandmapWindow()</slot>
+  <slot>bandComboChanged(QString)</slot>
  </slots>
 </ui>

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -1594,9 +1594,9 @@ void MainWindow::openNonVfoBandmap()
 {
     FCT_IDENTIFICATION;
     int newWindowNumber = 0;
-    for (int i = 1; i <= NONVFO_BANDMAP_MAX_INSTANCES;
-         i++) { // limit nonvfo bandmap windows to a maximum number of instances
-        if (settings.value(QString(NONVFO_BANDMAP_OBJECT_FORMATTER).arg(i)).isValid()) {
+    for (int i = 1; i <= NONVFO_BANDMAP_MAX_INSTANCES; i++) {
+        // limit nonvfo bandmap windows to a maximum number of instances
+        if (!settings.value(QString(NONVFO_BANDMAP_OBJECT_FORMATTER).arg(i)).isValid()) {
             newWindowNumber = i;
             break;
         }

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -43,6 +43,7 @@ public slots:
     void setLayoutGeometry();
     void setSimplyLayoutGeometry();
     void aboutToQuit();
+    void checkBandmapWidgets();
 
 private slots:
     void rigConnect();
@@ -116,7 +117,7 @@ private:
     QActionGroup *dupeGroup;
     QActionGroup *linkExchangeGroup;
     QPushButton *activityButton;
-    bool aboutToQuitFlag;
+    bool ignoreBandmapVisibility;
 
     void setDarkMode();
     void setLightMode();

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -42,6 +42,7 @@ public slots:
     void stationProfileChanged();
     void setLayoutGeometry();
     void setSimplyLayoutGeometry();
+    void aboutToQuit();
 
 private slots:
     void rigConnect();
@@ -88,6 +89,10 @@ private slots:
 
     void handleActivityChange(const QString name);
 
+    void openNonVfoBandmap();
+
+    void visibilityNonVfoBandmap(bool, QDockWidget *);
+
 private:
     Ui::MainWindow* ui;
     QLabel* conditionsLabel;
@@ -111,6 +116,7 @@ private:
     QActionGroup *dupeGroup;
     QActionGroup *linkExchangeGroup;
     QPushButton *activityButton;
+    bool aboutToQuitFlag;
 
     void setDarkMode();
     void setLightMode();
@@ -126,8 +132,11 @@ private:
     void restoreContestMenuSeqnoType();
     void restoreContestMenuDupeType();
     void restoreContestMenuLinkExchange();
+    void restoreNonVfoBandmaps();
 
     QString stationCallsignStatus(const StationProfile &profile) const;
+
+    void initializeNonVfoBandmap(const QString dockId);
 };
 
 #endif // QLOG_UI_MAINWINDOW_H

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>913</width>
-    <height>558</height>
+    <height>562</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string/>
   </property>
   <property name="dockOptions">
-   <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks|QMainWindow::GroupedDragging</set>
+   <set>QMainWindow::DockOption::AllowNestedDocks|QMainWindow::DockOption::AllowTabbedDocks|QMainWindow::DockOption::AnimatedDocks|QMainWindow::DockOption::GroupedDragging</set>
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -40,7 +40,7 @@
        </sizepolicy>
       </property>
       <property name="focusPolicy">
-       <enum>Qt::ClickFocus</enum>
+       <enum>Qt::FocusPolicy::ClickFocus</enum>
       </property>
      </widget>
     </item>
@@ -52,7 +52,7 @@
      <x>0</x>
      <y>0</y>
      <width>913</width>
-     <height>23</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -176,7 +176,7 @@
     <bool>false</bool>
    </property>
    <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonIconOnly</enum>
+    <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
    </property>
    <property name="floatable">
     <bool>false</bool>
@@ -214,7 +214,7 @@
    </attribute>
    <widget class="MapWidget" name="mapWidget">
     <property name="focusPolicy">
-     <enum>Qt::ClickFocus</enum>
+     <enum>Qt::FocusPolicy::ClickFocus</enum>
     </property>
    </widget>
   </widget>
@@ -247,7 +247,7 @@
   </widget>
   <widget class="QDockWidget" name="bandmapDockWidget">
    <property name="windowTitle">
-    <string>Bandmap</string>
+    <string>VFO Bandmap</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -310,8 +310,7 @@
   </widget>
   <action name="actionQuit">
    <property name="icon">
-    <iconset theme="application-exit">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="application-exit"/>
    </property>
    <property name="text">
     <string>Quit</string>
@@ -323,7 +322,7 @@
     <string notr="true">Ctrl+Q</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::QuitRole</enum>
+    <enum>QAction::MenuRole::QuitRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -331,20 +330,18 @@
   </action>
   <action name="actionSettings">
    <property name="icon">
-    <iconset theme="document-properties">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-properties"/>
    </property>
    <property name="text">
     <string>&amp;Settings</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::PreferencesRole</enum>
+    <enum>QAction::MenuRole::PreferencesRole</enum>
    </property>
   </action>
   <action name="actionNewContact">
    <property name="icon">
-    <iconset theme="document-new">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-new"/>
    </property>
    <property name="text">
     <string>New QSO - Clear</string>
@@ -361,8 +358,7 @@
   </action>
   <action name="actionImport">
    <property name="icon">
-    <iconset theme="document-import">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-import"/>
    </property>
    <property name="text">
     <string>&amp;Import</string>
@@ -370,8 +366,7 @@
   </action>
   <action name="actionExport">
    <property name="icon">
-    <iconset theme="document-export">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-export"/>
    </property>
    <property name="text">
     <string>&amp;Export</string>
@@ -390,20 +385,18 @@
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset theme="help-about">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="help-about"/>
    </property>
    <property name="text">
     <string>&amp;About</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::AboutRole</enum>
+    <enum>QAction::MenuRole::AboutRole</enum>
    </property>
   </action>
   <action name="actionSaveContact">
    <property name="icon">
-    <iconset theme="document-save">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="document-save"/>
    </property>
    <property name="text">
     <string>New QSO - Save</string>
@@ -438,8 +431,7 @@
   </action>
   <action name="actionStatistics">
    <property name="icon">
-    <iconset theme="x-office-spreadsheet">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="x-office-spreadsheet"/>
    </property>
    <property name="text">
     <string>S&amp;tatistics</string>
@@ -504,8 +496,7 @@
   </action>
   <action name="actionAwards">
    <property name="icon">
-    <iconset theme="application-certificate">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="application-certificate"/>
    </property>
    <property name="text">
     <string>&amp;Awards</string>
@@ -549,8 +540,7 @@
   </action>
   <action name="actionWikiHelp">
    <property name="icon">
-    <iconset theme="help">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset theme="help"/>
    </property>
    <property name="text">
     <string>&amp;Wiki</string>
@@ -627,10 +617,10 @@
     <string notr="true">Ctrl+F</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -647,10 +637,10 @@
     <string notr="true">Ctrl+M</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -664,10 +654,10 @@
     <string notr="true">Ctrl+PgDown</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -681,10 +671,10 @@
     <string notr="true">Ctrl+PgUp</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -698,10 +688,10 @@
     <string notr="true">Alt+Return</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -715,10 +705,10 @@
     <string notr="true">Alt+Up</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -732,10 +722,10 @@
     <string notr="true">Alt+Down</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -749,10 +739,10 @@
     <string notr="true">Alt+Right</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -766,10 +756,10 @@
     <string notr="true">Alt+Left</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>
@@ -783,13 +773,13 @@
     <string notr="true">Alt+\</string>
    </property>
    <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
+    <enum>Qt::ShortcutContext::ApplicationShortcut</enum>
    </property>
    <property name="autoRepeat">
     <bool>false</bool>
    </property>
    <property name="menuRole">
-    <enum>QAction::NoRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
    <property name="changeableshortcut" stdset="0">
     <bool>true</bool>


### PR DESCRIPTION
closes #339 

Attempt at adding multiple bandmap windows, using the existing right click menu to change which band is displayed. The VFO linked bandmap serves as the "master" which manages the spot data model shared with the non-vfo bandmaps. The user may close the vfo bandmap but it continues to operate in the background as it always has. This master vfo bandmap is also used to launch new non-vfo bandmaps and continues to provide the existing `clear all` and spot expiry features. I've tried to reuse as much of the existing bandmap as possible for the non-vfo bandmaps. Basically they are stripped of rig link and data management.

This change introduces a new concept around dockwidgets, which is the actual deletion and removal of dockwidgets when they are closed. This goal so far has been unexpectedly buggy, which is why you see some weird management code in mainwindow, even though this feature is meant to be built into qt but it doesn't work in many different scenarios. (WA_DeleteOnClose)

There are some remaining items to clean up which I will continue with if @foldynl gives the go ahead for this feature.
![Screenshot 2025-02-06 at 9 22 35 PM](https://github.com/user-attachments/assets/70a955a7-021e-40e7-a443-beb62709c0fb)

[Kapture 2025-02-06 at 21.41.34.webm](https://github.com/user-attachments/assets/91a01683-e897-48ab-b809-adb8bd92d121)


(I gave up working on split mode support, too many design choices to do on my own)
