### PR TITLE
Update LogLocale.cpp

### DIFF
--- a/core/LogLocale.cpp
+++ b/core/LogLocale.cpp
@@ -4,7 +4,7 @@
 MODULE_IDENTIFICATION("qlog.core.loglocale");
 
 LogLocale::LogLocale() :
-    regexp(QRegularExpression(R"(, tttt|\(t\)|\bt\b)")),
+    regexp(QRegularExpression(R"(, tttt|\(t\)|\bt\b|\btt\b)")),
     is24hUsed(!timeFormat(QLocale::ShortFormat).contains("ap", Qt::CaseInsensitive))
 {
     FCT_IDENTIFICATION;


### PR DESCRIPTION
On MacOS at least the time had a +0000 at the end not sure if that was intentional.  It looked like you had a regex to try and remove some stuff at the end of the time format.  I added another case to remove that. 
![Time on](https://github.com/user-attachments/assets/c6a2ea64-36fe-40bc-b7df-d391197b5fea)
