### PR TITLE
PropConditions::dxTrendTimeout Error

### DIFF
--- a/core/PropConditions.cpp
+++ b/core/PropConditions.cpp
@@ -288,10 +288,13 @@ void PropConditions::dxTrendTimeout()
 {
     FCT_IDENTIFICATION;
 
-    for ( auto it = dxTrendPendingConnections.begin(); it != dxTrendPendingConnections.end(); ++it )
+    if (!dxTrendPendingConnections.isEmpty())
     {
-        (*it)->abort();
-        (*it)->deleteLater();
+        for ( auto it = dxTrendPendingConnections.begin(); it != dxTrendPendingConnections.end(); ++it )
+        {
+            (*it)->abort();
+            (*it)->deleteLater();
+        }
     }
     dxTrendResult.clear();
     emit dxTrendFinalized(dxTrendResult); // emit empty result


### PR DESCRIPTION
If no Telnet cluster is connected it would cause QLog to crash when this event fired.  Added a check to only do the for loop if dxTrendPendingConnections is not empty.