### PR TITLE
Issue601

### DIFF
--- a/ui/QSODetailDialog.cpp
+++ b/ui/QSODetailDialog.cpp
@@ -1586,7 +1586,8 @@ void QSODetailDialog::refreshDXStatTabs()
     FCT_IDENTIFICATION;
 
     const QString &currCallsign = ui->callsignEdit->text();
-    const DxccEntity &dxccEntity = Data::instance()->lookupDxcc(currCallsign);
+    const DxccEntity &dxccEntity = Data::instance()->lookupDxccID(editedRecord->field("dxcc").value().toInt());
+   // const DxccEntity &dxccEntity = Data::instance()->lookupDxcc(currCallsign);
     const Band &currBand = BandPlan::freq2Band(ui->freqTXEdit->value());
 
     ui->dxccTableWidget->setDxcc(dxccEntity.dxcc, currBand);


### PR DESCRIPTION
This is a an attempt to resovle issue #601  . Currently the code is written to map the callsign to DXCC.  In certain instances this will map to incorrect DXCCs.  I made an attempt to have it reference what is stored as the DXCC on the QSL record.