### PR TITLE
CSN S.A.T. Device UDP

### DIFF
--- a/.github/workflows/macOSBuild.yml
+++ b/.github/workflows/macOSBuild.yml
@@ -13,7 +13,7 @@ jobs:
      name: MacOS Build
      strategy:
        matrix:
-         os: [macos-12, macos-13]
+         os: [macos-15]
 
      runs-on: ${{ matrix.os }}
 
@@ -32,11 +32,31 @@ jobs:
          brew install brotli
          brew install icu4c
          brew install pkg-config
+         brew install automake
+         brew install autoconf
+         brew install libtool
+         brew install libusb-compat
+         
      - name: Checkout Code
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
          submodules: recursive
+     - name: Checkout Code
+       uses: actions/checkout@v4
+       with:
+         repository: hamlib/hamlib
+         path: ./hamlib
+         ref: Hamlib-4.6.2
+         
+     - name: Configure and compile
+       run: |
+         cd ./hamlib
+         ./bootstrap
+         ./configure --prefix=/Users/runner/work/QLog/QLog/hamlib
+         make -j 4
+         make check
+         make install
      - name: Get version from tag
        run : |
          TAGVERSION=$(git describe --tags)
@@ -46,26 +66,118 @@ jobs:
        run: |
          mkdir build
          cd build
-         qmake -config release ..
+         qmake "HAMLIBINCLUDEPATH = /Users/runner/work/QLog/QLog/hamlib/include" "HAMLIBLIBPATH = /Users/runner/work/QLog/QLog/hamlib/lib" "HAMLIBVERSION_MAJOR = 4" "HAMLIBVERSION_MINOR = 6" "HAMLIBVERSION_PATCH = 0" -config release ..
          make -j4
      - name: Build dmg
        run: |
          cd build
-         macdeployqt qlog.app -executable=./qlog.app/Contents/MacOS/qlog
-         cp `brew --prefix`/lib/libhamlib.dylib qlog.app/Contents/Frameworks/libhamlib.dylib
-         cp `brew --prefix`/lib/libqt6keychain.dylib qlog.app/Contents/Frameworks/libqt6keychain.dylib
-         cp `brew --prefix`/lib/libdbus-1.dylib qlog.app/Contents/Frameworks/libdbus-1.dylib
-         cp `brew --prefix brotli`/lib/libbrotlicommon.1.dylib qlog.app/Contents/Frameworks/libbrotlicommon.1.dylib
-         cp `brew --prefix`/opt/icu4c/lib/libicui18n.74.dylib qlog.app/Contents/Frameworks/libicui18n.74.dylib
-         install_name_tool -change `brew --prefix`/lib/libhamlib.dylib @executable_path/../Frameworks/libhamlib.dylib qlog.app/Contents/MacOS/qlog
-         install_name_tool -change `brew --prefix`/lib/libqt6keychain.dylib @executable_path/../Frameworks/libqt6keychain.dylib qlog.app/Contents/MacOS/qlog
-         install_name_tool -change @loader_path/libbrotlicommon.1.dylib @executable_path/../Frameworks/libbrotlicommon.1.dylib qlog.app/Contents/MacOS/qlog 
-         install_name_tool -change /usr/local/opt/icu4c/lib/libicui18n.74.dylib @executable_path/../Frameworks/libicui18n.74.dylib qlog.app/Contents/MacOS/qlog
-         otool -L qlog.app/Contents/MacOS/qlog
-         macdeployqt qlog.app -dmg
+         macdeployqt qlog.app -executable=./qlog.app/Contents/MacOS/qlog 
+         macdeployqt qlog.app
+     - name: Codesign app bundle
+         # Extract the secrets we defined earlier as environment variables
+       env: 
+           MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+       run: |
+           # Turn our base64-encoded certificate back to a regular .p12 file
+           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+           # We need to create a new keychain, otherwise using the certificate will prompt
+           # with a UI dialog asking for the certificate password, which we can't
+           # use in a headless CI environment
+           security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
+           security default-keychain -s build.keychain
+           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+           security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+           # We finally codesign our app bundle, specifying the Hardened runtime option
+           sudo codesign --deep --force --verify --verbose --sign "$MACOS_CERTIFICATE_NAME" --options runtime /Users/runner/work/QLog/QLog/build/qlog.app
+           sudo codesign --force --verify --verbose --sign "$MACOS_CERTIFICATE_NAME" --entitlements /Users/runner/work/QLog/QLog/entitlements.xml --options runtime /Users/runner/work/QLog/QLog/build/qlog.app/Contents/Frameworks/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
+           sudo codesign --force --verify --verbose --sign "$MACOS_CERTIFICATE_NAME" --options runtime /Users/runner/work/QLog/QLog/build/qlog.app/Contents/MacOS/qlog
+     - name: "Notarize app bundle"
+         # Extract the secrets we defined earlier as environment variables
+       env:
+           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+           PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+           PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+       run: |
+           # Store the notarization credentials so that we can prevent a UI password dialog
+           # from blocking the CI
+
+           echo "Create keychain profile"
+           xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+           
+           echo "Creating temp notarization archive"
+           ditto -c -k --keepParent "/Users/runner/work/QLog/QLog/build/qlog.app" "notarization.zip"
+
+           # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+           # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+           # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+           # you're curious
+
+           echo "Notarize app"
+           xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+
+           echo "Attach staple"
+           xcrun stapler staple "/Users/runner/work/QLog/QLog/build/qlog.app"   
+     - name: make dmg
+       run: |
+         mkdir out
+         cp -R "/Users/runner/work/QLog/QLog/build/qlog.app" out
+         cd out
+         ln -s /Applications/ Applications
+         cd ..
+         hdiutil create -volname "QLog Installer" -srcfolder out -ov -format UDZO "/Users/runner/work/QLog/QLog/build/qlog.dmg"
+     - name: Codesign dmg bundle
+         # Extract the secrets we defined earlier as environment variables
+       env: 
+           MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+           MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+           MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+       run: |
+           # Turn our base64-encoded certificate back to a regular .p12 file
+           ##echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+           # We need to create a new keychain, otherwise using the certificate will prompt
+           # with a UI dialog asking for the certificate password, which we can't
+           # use in a headless CI environment
+           ##security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
+           ##security default-keychain -s build.keychain
+           ##security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+           ##security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+           ##security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+           # We finally codesign our app bundle, specifying the Hardened runtime option
+           /usr/bin/codesign --timestamp -s "$MACOS_CERTIFICATE_NAME" --options runtime --deep -f /Users/runner/work/QLog/QLog/build/qlog.dmg
+     - name: "Notarize app bundle"
+         # Extract the secrets we defined earlier as environment variables
+       env:
+           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+           PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+           PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+       run: |
+           # Store the notarization credentials so that we can prevent a UI password dialog
+           # from blocking the CI
+
+           echo "Create keychain profile"
+           xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+           
+           echo "Creating temp notarization archive"
+           ditto -c -k --keepParent "/Users/runner/work/QLog/QLog/build/qlog.dmg" "notarization.zip"
+
+           # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+           # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+           # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+           # you're curious
+
+           echo "Notarize app"
+           xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+
+           echo "Attach staple"
+           xcrun stapler staple "/Users/runner/work/QLog/QLog/build/qlog.dmg"           
+         
      - name: Copy artifact
        uses: actions/upload-artifact@v4
        with:
          name: QLog-${{ env.TAGVERSION }}-${{ matrix.os }}
          path: /Users/runner/work/QLog/QLog/build/qlog.dmg
-

--- a/core/Wsjtx.cpp
+++ b/core/Wsjtx.cpp
@@ -260,6 +260,8 @@ void Wsjtx::readPendingDatagrams()
 
         QDataStream stream(datagram.data());
 
+        bool IsCSNSat = datagram.data().contains("CSN Sat");
+
         quint32 magic, schema, mtype;
         stream >> magic;
         stream >> schema;
@@ -382,8 +384,18 @@ void Wsjtx::readPendingDatagrams()
             QByteArray id, adif_text;
             WsjtxLogADIF log;
 
-            stream >> id >> adif_text;
+            QByteArray t = datagram.data();
 
+            if(IsCSNSat)
+            {
+                id = "CSN Sat";
+                adif_text = datagram.data();
+                adif_text = adif_text.mid(adif_text.indexOf("<adif_ver:"));
+            }
+            else
+            {
+                stream >> id >> adif_text;
+            }
             log.id = QString(id);
             log.log_adif = QString(adif_text);
 

--- a/core/Wsjtx.cpp
+++ b/core/Wsjtx.cpp
@@ -260,8 +260,6 @@ void Wsjtx::readPendingDatagrams()
 
         QDataStream stream(datagram.data());
 
-        bool IsCSNSat = datagram.data().contains("CSN Sat");
-
         quint32 magic, schema, mtype;
         stream >> magic;
         stream >> schema;
@@ -385,6 +383,8 @@ void Wsjtx::readPendingDatagrams()
             WsjtxLogADIF log;
 
             QByteArray t = datagram.data();
+
+            bool IsCSNSat = datagram.data().contains("<programid:6>CSN Sat");
 
             if(IsCSNSat)
             {

--- a/core/Wsjtx.cpp
+++ b/core/Wsjtx.cpp
@@ -382,8 +382,6 @@ void Wsjtx::readPendingDatagrams()
             QByteArray id, adif_text;
             WsjtxLogADIF log;
 
-            QByteArray t = datagram.data();
-
             bool IsCSNSat = datagram.data().contains("<programid:6>CSN Sat");
 
             if(IsCSNSat)

--- a/entitlements.xml
+++ b/entitlements.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+<key>com.apple.security.cs.disable-library-validation</key><true/>
+<key>com.apple.security.cs.allow-jit</key><true/>
+<key>com.apple.security.cs.disable-executable-page-protection</key>
+<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I've recently starting to try and operate Satellites.  I am using one of these devices.  It has an option to perform logging as well as can either export log entries or send a UDP blast.  It has an option it says is for MacLoggerDX over port 2237.  Which made me think QLog should be able to grab it.  But looks like it usings 99% the format of WSJT-X.  I made a condition to try and detect if the UDP from the CSN device and try to account for it not reading the adif_text part of the blast.  I did also open a support request with the vendor to see if they may could make an adjustment so it would more align with the WSJT-X.  From looking at it, it appears it may be missing a " before the <ADIF_VER> tag.
WSJT-X
![Pasted Graphic](https://github.com/user-attachments/assets/ba29f826-bcbc-4c7d-920b-f9cebe9939f2)
CSN SAT
![Pasted Graphic 1](https://github.com/user-attachments/assets/592e2424-75f2-44c9-aef4-77499802fe9b)


If they are able to make it work on this end I will kill this Pull request, if not I would like for it to be considered.

I built a test version so you can ignore the entitlements and action file.

Thanks