### PR TITLE
DXCC Stats still including deleted entities - AwardsDialog.cpp

### DIFF
--- a/ui/AwardsDialog.cpp
+++ b/ui/AwardsDialog.cpp
@@ -144,8 +144,15 @@ void AwardsDialog::refreshTable(int)
                           "  SELECT * "
                           "  FROM contacts )";
 
+
     if ( awardSelected == "dxcc" )
     {
+        sourceContactsTable = " source_contacts AS ("
+                              "  SELECT * "
+                              "  FROM contacts c "
+                              "  inner join "
+                              "  dxcc_entities d on "
+                              "  c.dxcc =d.id )";
         setEntityInputEnabled(true);
         setNotWorkedEnabled(true);
         const QString &entitySelected = getSelectedEntity();


### PR DESCRIPTION
I noticed the when looking at code for the email earlier that the DXCC counts were still including Deleted Entities.  Mine was showing 323 instead of 320 confirmed.  I made an adjustment to correct but not sure if it is the ideal way.