### PR TITLE
Update NewContactWidget.cpp

### DIFF
--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -3192,6 +3192,8 @@ void NewContactWidget::setValuesFromActivity(const QString &name)
     setFieldValueCombo(LogbookModel::LogbookModel::COLUMN_PROP_MODE, ui->propagationModeEdit);
     setFieldValueCombo(LogbookModel::LogbookModel::COLUMN_SAT_MODE, uiDynamic->satModeEdit);
     setFieldValue(LogbookModel::COLUMN_SAT_NAME, uiDynamic->satNameEdit);
+
+    setContestFieldsState();
 }
 
 void NewContactWidget::rigProfileComboChanged(const QString &profileName)


### PR DESCRIPTION
Set the Context Fields State when Activities Change.

It would not enable the fields at first because the widget didn't recognize the contest id as being set.