### PR TITLE
feat: add unit system setting in gui tab

### DIFF
--- a/core/Gridsquare.cpp
+++ b/core/Gridsquare.cpp
@@ -132,19 +132,32 @@ const QRegularExpression Gridsquare::gridExtRegEx()
 }
 
 double Gridsquare::distance2localeUnitDistance(double km,
-                                               QString &unit)
+                                               QString &unit,
+                                               LogLocale &locale)
 {
     FCT_IDENTIFICATION;
 
     unit = QObject::tr("km");
     double ret = km;
 
-    // All imperial systems
-    if ( QLocale::system().measurementSystem() != QLocale::MetricSystem)
-    {
+    UnitFormat chosenUnit = locale.getSettingUnitFormat();
+    switch (chosenUnit) {
+    case UnitFormat::System:
+        // All imperial systems
+        if ( QLocale::system().measurementSystem() != QLocale::MetricSystem)
+        {
+            unit = QObject::tr("miles");
+            ret = km * localeDistanceCoef();
+        }
+        break;
+    case UnitFormat::Imperial:
         unit = QObject::tr("miles");
         ret = km * localeDistanceCoef();
+        break;
+    case UnitFormat::Metric:
+        break;
     }
+
     return ret;
 }
 

--- a/core/Gridsquare.cpp
+++ b/core/Gridsquare.cpp
@@ -133,7 +133,7 @@ const QRegularExpression Gridsquare::gridExtRegEx()
 
 double Gridsquare::distance2localeUnitDistance(double km,
                                                QString &unit,
-                                               LogLocale &locale)
+                                               const LogLocale &locale)
 {
     FCT_IDENTIFICATION;
 

--- a/core/Gridsquare.h
+++ b/core/Gridsquare.h
@@ -5,6 +5,8 @@
 #include <QString>
 #include <QDebug>
 
+#include "core/LogLocale.h"
+
 class Gridsquare
 {
 public:
@@ -14,7 +16,7 @@ public:
     static const QRegularExpression gridRegEx();
     static const QRegularExpression gridVUCCRegEx();
     static const QRegularExpression gridExtRegEx();
-    static double distance2localeUnitDistance(double km, QString &unit);
+    static double distance2localeUnitDistance(double km, QString &unit, LogLocale &locale);
     static double localeDistanceCoef();
 
     bool isValid() const;

--- a/core/Gridsquare.h
+++ b/core/Gridsquare.h
@@ -16,7 +16,7 @@ public:
     static const QRegularExpression gridRegEx();
     static const QRegularExpression gridVUCCRegEx();
     static const QRegularExpression gridExtRegEx();
-    static double distance2localeUnitDistance(double km, QString &unit, LogLocale &locale);
+    static double distance2localeUnitDistance(double km, QString &unit, const LogLocale &locale);
     static double localeDistanceCoef();
 
     bool isValid() const;

--- a/core/LogLocale.cpp
+++ b/core/LogLocale.cpp
@@ -108,6 +108,21 @@ void LogLocale::setSettingUseSystemDateFormat(bool value)
     settings.setValue("usesystemdateformat", value);
 }
 
+const UnitFormat LogLocale::getSettingUnitFormat() const
+{
+    QVariant value = settings.value("useunitformat", unit_format);
+
+    int savedUnit = value.value<int>();
+    UnitFormat unit = static_cast<UnitFormat>(savedUnit);
+
+    return unit;
+}
+
+void LogLocale::setSettingUnitFormat(UnitFormat value)
+{
+    settings.setValue("useunitformat", value);
+}
+
 const QString LogLocale::getSettingDateFormat() const
 {
     return settings.value("customdateformatstring", systemDateFormat).toString();

--- a/core/LogLocale.h
+++ b/core/LogLocale.h
@@ -5,6 +5,8 @@
 #include <QLocale>
 #include <QRegularExpression>
 
+enum UnitFormat { System, Imperial, Metric };
+
 class LogLocale : public QLocale
 {
 public:
@@ -21,16 +23,21 @@ public:
     bool getSettingUseSystemDateFormat() const;
     void setSettingUseSystemDateFormat(bool value);
 
+    const UnitFormat getSettingUnitFormat() const;
+    void setSettingUnitFormat(UnitFormat value);
+
     const QString getSettingDateFormat() const;
     void setSettingDateFormat(const QString &value);
 
 private:
     const QRegularExpression regexp;
     bool is24hUsed;
+    UnitFormat unit_format;
     QSettings settings;
     QString systemDateFormat;
 
     void changeTime12_24Format(QString &formatString) const;
 };
+
 
 #endif // QLOG_CORE_LOGLOCALE_H

--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -2168,7 +2168,7 @@ void NewContactWidget::updateCoordinates(double lat, double lon, CoordPrecision 
     {
         dxDistance = distance;
         QString unit;
-        double showDistance = Gridsquare::distance2localeUnitDistance(dxDistance, unit);
+        double showDistance = Gridsquare::distance2localeUnitDistance(dxDistance, unit, locale);
         double LPBearing = bearing - 180;
 
         if ( LPBearing < 0 )

--- a/ui/QSODetailDialog.cpp
+++ b/ui/QSODetailDialog.cpp
@@ -1421,7 +1421,7 @@ void QSODetailDialog::drawDXOnMap(const QString &label, const Gridsquare &dxGrid
     double distance = 0;
 
     if (dxGrid.distanceTo(myGrid, distance)) {
-        distance = Gridsquare::distance2localeUnitDistance(distance, unit);
+        distance = Gridsquare::distance2localeUnitDistance(distance, unit, locale);
         popupString.append(QString("</br> %1 %2").arg(QString::number(distance, 'f', 0), unit));
     }
 

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -2366,6 +2366,24 @@ void SettingsDialog::readSettings() {
     ui->timeFormat24RadioButton->setChecked(timeformat24);
     ui->timeFormat12RadioButton->setChecked(!timeformat24);
 
+    UnitFormat unitFormat = locale.getSettingUnitFormat();
+    switch (unitFormat) {
+    case UnitFormat::System:
+      ui->unitFormatSystemRadioButton->setChecked(true);
+      ui->unitFormatImperialRadioButton->setChecked(false);
+      ui->unitFormatMetricRadioButton->setChecked(false);
+      break;
+    case UnitFormat::Imperial:
+      ui->unitFormatSystemRadioButton->setChecked(false);
+      ui->unitFormatImperialRadioButton->setChecked(true);
+      ui->unitFormatMetricRadioButton->setChecked(false);
+      break;
+    case UnitFormat::Metric:
+      ui->unitFormatSystemRadioButton->setChecked(false);
+      ui->unitFormatImperialRadioButton->setChecked(false);
+      ui->unitFormatMetricRadioButton->setChecked(true);
+      break;
+    }
     bool dateSystemFormat = locale.getSettingUseSystemDateFormat();
     ui->dateFormatSystemRadioButton->setChecked(dateSystemFormat);
     ui->dateFormatCustomRadioButton->setChecked(!dateSystemFormat);
@@ -2486,12 +2504,27 @@ void SettingsDialog::writeSettings() {
     /*******/
     /* GUI */
     /*******/
+    // Time format
     locale.setSettingUse24hformat(ui->timeFormat24RadioButton->isChecked());
 
+    // Date format
     bool systemDateChecked = ui->dateFormatSystemRadioButton->isChecked();
     locale.setSettingUseSystemDateFormat(systemDateChecked);
     if ( !systemDateChecked )
         locale.setSettingDateFormat(ui->dateFormatStringEdit->text());
+
+    // Unit format
+    UnitFormat chosenUnit = getChosenUnitFormat();
+    locale.setSettingUnitFormat(chosenUnit);
+}
+UnitFormat SettingsDialog::getChosenUnitFormat() {
+    if (ui->unitFormatMetricRadioButton->isChecked()) {
+            return UnitFormat::Metric;
+    } else if (ui->unitFormatImperialRadioButton->isChecked()) {
+            return UnitFormat::Imperial;
+    } else {
+            return UnitFormat::System;
+    }
 }
 
 /* this function is called when user modify rig progile

--- a/ui/SettingsDialog.h
+++ b/ui/SettingsDialog.h
@@ -128,6 +128,8 @@ private:
     QString getMemberListComboValue(const QComboBox *);
     void generateMembershipCheckboxes();
 
+    UnitFormat getChosenUnitFormat();
+
     QSqlTableModel* modeTableModel;
     QSqlTableModel* bandTableModel;
     StationProfilesManager *stationProfManager;

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -42,7 +42,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>9</number>
      </property>
      <property name="documentMode">
       <bool>false</bool>
@@ -3601,8 +3601,7 @@
                 <string>Browse</string>
                </property>
                <property name="icon">
-                <iconset theme="folder-open">
-                 <normaloff>.</normaloff>.</iconset>
+                <iconset theme="folder-open"/>
                </property>
               </widget>
              </item>
@@ -4365,6 +4364,51 @@
             </spacer>
            </item>
           </layout>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_37" stretch="0,0,0,0">
+           <item>
+            <widget class="QRadioButton" name="unitFormatSystemRadioButton">
+             <property name="text">
+              <string>System</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="unitFormatImperialRadioButton">
+             <property name="text">
+              <string>Imperial</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="unitFormatMetricRadioButton">
+             <property name="text">
+              <string>Metric</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_7">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="unitSystemLabel">
+           <property name="text">
+            <string>Unit Format</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -5684,7 +5728,7 @@
   <slot>updateDateFormatResult()</slot>
  </slots>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/ui/StatisticsWidget.cpp
+++ b/ui/StatisticsWidget.cpp
@@ -340,7 +340,7 @@ void StatisticsWidget::refreshGraph()
              break;
          case 2: // ODX
              QString unit;
-             Gridsquare::distance2localeUnitDistance(0, unit);
+             Gridsquare::distance2localeUnitDistance(0, unit, locale);
              QString distCoef = QString::number(Gridsquare::localeDistanceCoef());
              QString sel = QString("SELECT callsign || '<br>' || CAST(ROUND(distance * %1,0) AS INT) || ' %2', gridsquare, my_gridsquare, ").arg(distCoef, unit);
 
@@ -735,7 +735,7 @@ void StatisticsWidget::setSubTypesCombo(int mainTypeIdx)
     case 3:
     {
         QString unit;
-        Gridsquare::distance2localeUnitDistance(0, unit);
+        Gridsquare::distance2localeUnitDistance(0, unit, locale);
         ui->statTypeSecCombo->addItem(tr("Distance") + QString(" [%1]").arg(unit));
     }
     break;

--- a/ui/StyleItemDelegate.h
+++ b/ui/StyleItemDelegate.h
@@ -220,8 +220,7 @@ public:
 
     QString displayText(const QVariant& value, const QLocale&) const {
         QString unit;
-        // double displayValue = Gridsquare::distance2localeUnitDistance(value.toDouble(), unit, locale);
-        double displayValue = 1.0;
+        double displayValue = Gridsquare::distance2localeUnitDistance(value.toDouble(), unit, locale);
         return QString("%1 %2").arg(QString::number(displayValue, 'f', precision), unit);
     }
 

--- a/ui/StyleItemDelegate.h
+++ b/ui/StyleItemDelegate.h
@@ -207,6 +207,8 @@ private:
 };
 
 class DistanceFormatDelegate : public QStyledItemDelegate {
+private:
+    LogLocale locale;
 public:
     DistanceFormatDelegate(int precision, double step, QObject* parent = 0) :
         QStyledItemDelegate(parent), precision(precision), step(step) { }
@@ -218,7 +220,8 @@ public:
 
     QString displayText(const QVariant& value, const QLocale&) const {
         QString unit;
-        double displayValue = Gridsquare::distance2localeUnitDistance(value.toDouble(), unit);
+        // double displayValue = Gridsquare::distance2localeUnitDistance(value.toDouble(), unit, locale);
+        double displayValue = 1.0;
         return QString("%1 %2").arg(QString::number(displayValue, 'f', precision), unit);
     }
 

--- a/ui/WsjtxFilterDialog.cpp
+++ b/ui/WsjtxFilterDialog.cpp
@@ -16,7 +16,7 @@ WsjtxFilterDialog::WsjtxFilterDialog(QWidget *parent) :
     ui->setupUi(this);
 
     QString unit;
-    // Gridsquare::distance2localeUnitDistance(0, unit);
+    Gridsquare::distance2localeUnitDistance(0, unit, locale);
     ui->distanceSpinBox->setSuffix(" " + unit);
 
     /*********************/

--- a/ui/WsjtxFilterDialog.cpp
+++ b/ui/WsjtxFilterDialog.cpp
@@ -16,7 +16,7 @@ WsjtxFilterDialog::WsjtxFilterDialog(QWidget *parent) :
     ui->setupUi(this);
 
     QString unit;
-    Gridsquare::distance2localeUnitDistance(0, unit);
+    // Gridsquare::distance2localeUnitDistance(0, unit);
     ui->distanceSpinBox->setSuffix(" " + unit);
 
     /*********************/

--- a/ui/WsjtxFilterDialog.h
+++ b/ui/WsjtxFilterDialog.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QCheckBox>
 #include <QSet>
+#include "core/LogLocale.h"
 
 namespace Ui {
 class WsjtxFilterDialog;
@@ -22,6 +23,7 @@ private:
     Ui::WsjtxFilterDialog *ui;
     QList<QCheckBox*> memberListCheckBoxes;
     QSet<QString> dxMemberFilter;
+    LogLocale locale;
 
     void generateMembershipCheckboxes();
 

--- a/ui/WsjtxWidget.cpp
+++ b/ui/WsjtxWidget.cpp
@@ -110,7 +110,7 @@ void WsjtxWidget::decodeReceived(WsjtxDecode decode)
 
             if ( entry.dxcc.cont.contains(contregexp)
                  && ( entry.status & dxccStatusFilter )
-                 && Gridsquare::distance2localeUnitDistance(entry.distance, unit) >= distanceFilter
+                 // && Gridsquare::distance2localeUnitDistance(entry.distance, unit) >= distanceFilter
                  && entry.decode.snr >= snrFilter
                  && ( dxMemberFilter.size() == 0
                       || (dxMemberFilter.size() && entry.memberList2Set().intersects(dxMemberFilter)))

--- a/ui/WsjtxWidget.cpp
+++ b/ui/WsjtxWidget.cpp
@@ -110,7 +110,7 @@ void WsjtxWidget::decodeReceived(WsjtxDecode decode)
 
             if ( entry.dxcc.cont.contains(contregexp)
                  && ( entry.status & dxccStatusFilter )
-                 // && Gridsquare::distance2localeUnitDistance(entry.distance, unit) >= distanceFilter
+                 && Gridsquare::distance2localeUnitDistance(entry.distance, unit, locale) >= distanceFilter
                  && entry.decode.snr >= snrFilter
                  && ( dxMemberFilter.size() == 0
                       || (dxMemberFilter.size() && entry.memberList2Set().intersects(dxMemberFilter)))

--- a/ui/WsjtxWidget.h
+++ b/ui/WsjtxWidget.h
@@ -7,6 +7,7 @@
 #include "data/WsjtxEntry.h"
 #include "models/WsjtxTableModel.h"
 #include "rig/Rig.h"
+#include "core/LogLocale.h"
 
 namespace Ui {
 class WsjtxWidget;
@@ -64,6 +65,7 @@ private:
     QSet<QString> dxMemberFilter;
     void saveTableHeaderState();
     void restoreTableHeaderState();
+    LogLocale locale;
 };
 
 #endif // QLOG_UI_WSJTXWIDGET_H


### PR DESCRIPTION
AFAIK, one's system's QLocale setting determines the unit system in which distances are displayed, i.e. Metric or Imperial.

This patch adds a new setting in the GUI tab to set a QLog specific preference, without having to modify the unit system used system-wide.

The current implementation looks like this:
![image](https://github.com/user-attachments/assets/ef19af5f-8718-4518-b4d1-2be85e3df711)

Would love to get some feedback on this!

PS: QLog is awesome, thanks for all the work.