### PR TITLE
feat(cluster): Enables sorting and add state column

### DIFF
--- a/data/DxSpot.h
+++ b/data/DxSpot.h
@@ -28,6 +28,7 @@ public:
     DxccEntity dxcc;
     DxccEntity dxcc_spotter;
     DxccStatus status;
+    QString state;
     bool containsWWFF;
     bool containsPOTA;
     bool containsSOTA;

--- a/ui/DxWidget.cpp
+++ b/ui/DxWidget.cpp
@@ -407,6 +407,8 @@ DxWidget::DxWidget(QWidget *parent) :
     separator->setSeparator(true);
 
     ui->dxTable->setModel(dxTableProxyModel);
+    ui->dxTable->setSortingEnabled(true);
+    ui->dxTable->sortByColumn(0, Qt::DescendingOrder); // Sort by Time column, newest first
     ui->dxTable->addAction(ui->actionFilter);
     ui->dxTable->addAction(ui->actionSearch);
     ui->dxTable->addAction(ui->actionDisplayedColumns);
@@ -421,16 +423,22 @@ DxWidget::DxWidget(QWidget *parent) :
     ui->dxTable->horizontalHeader()->setSectionsMovable(true);
 
     ui->wcyTable->setModel(wcyTableModel);
+    ui->wcyTable->setSortingEnabled(true);
+    ui->wcyTable->sortByColumn(0, Qt::DescendingOrder); // Sort by Time column, newest first
     ui->wcyTable->addAction(ui->actionDisplayedColumns);
     ui->wcyTable->addAction(ui->actionClear);
     ui->wcyTable->horizontalHeader()->setSectionsMovable(true);
 
     ui->wwvTable->setModel(wwvTableModel);
+    ui->wwvTable->setSortingEnabled(true);
+    ui->wwvTable->sortByColumn(0, Qt::DescendingOrder); // Sort by Time column, newest first
     ui->wwvTable->addAction(ui->actionDisplayedColumns);
     ui->wwvTable->addAction(ui->actionClear);
     ui->wwvTable->horizontalHeader()->setSectionsMovable(true);
 
     ui->toAllTable->setModel(toAllTableModel);
+    ui->toAllTable->setSortingEnabled(true);
+    ui->toAllTable->sortByColumn(0, Qt::DescendingOrder); // Sort by Time column, newest first
     ui->toAllTable->addAction(ui->actionDisplayedColumns);
     ui->toAllTable->addAction(ui->actionClear);
     ui->toAllTable->horizontalHeader()->setSectionsMovable(true);

--- a/ui/DxWidget.h
+++ b/ui/DxWidget.h
@@ -246,6 +246,7 @@ private:
     void potaRefFromComment(DxSpot &spot) const;
     void sotaRefFromComment(DxSpot &spot) const;
     void iotaRefFromComment(DxSpot &spot) const;
+    void stateFromComment(DxSpot &spot) const;
 
     QColor getHeatmapColor(int value, int maxValue);
 };


### PR DESCRIPTION
Improves the user experience by enabling sorting on tables.

Also sorts the Dx, Wcy, Wwv, and ToAll tables by the 'Time' column in descending order by default, ensuring that the newest entries are displayed first.