### PR TITLE
Added Info for Logged WSJTX Contacts

### DIFF
--- a/core/WsjtxUDPReceiver.cpp
+++ b/core/WsjtxUDPReceiver.cpp
@@ -547,6 +547,31 @@ void WsjtxUDPReceiver::insertContact(WsjtxLogADIF log)
     // Therefore, it is necessary to save the first record and possibly update it
     // with the second record and then emit the result.
     // For this we create an updatable SQLRecord
+
+    constexpr double TOLERANCE_KHZ = 0.005; // 5 kHz = 0.005 MHz
+    for (const DxSpot &spot : dxData) {
+        if (spot.callsign.compare(record.value("callsign").toString(), Qt::CaseInsensitive) == 0 &&
+            qAbs(spot.freq - record.value("freq").toDouble()) <= TOLERANCE_KHZ)
+        {
+            if(spot.containsPOTA)
+            {
+                record.setValue("pota_ref",spot.potaRef);
+            }
+            if(spot.containsIOTA)
+            {
+                record.setValue("iota_ref",spot.iotaRef);
+            }
+            if(spot.containsSOTA)
+            {
+                record.setValue("sota_ref",spot.sotaRef);
+            }
+            if(spot.containsWWFF)
+            {
+                record.setValue("wwff_ref",spot.wwffRef);
+            }
+        }
+    }
+
     wsjtSQLRecord.updateRecord(record);
     //emit addContact(record);
 }
@@ -587,3 +612,15 @@ void WsjtxUDPReceiver::reloadSetting()
 
 int     WsjtxUDPReceiver::DEFAULT_PORT = 2237;
 QString WsjtxUDPReceiver::CONFIG_MULTICAST_TTL = "network/wsjtx_multicast_ttl";
+
+void WsjtxUDPReceiver::dxSpot(const DxSpot &spot)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(function_parameters) << "DX Spot";
+
+    if(spot.modeGroupString.startsWith("FT") || spot.modeGroupString.startsWith("DIGITAL"))
+    {
+        dxData.append(spot);
+    }
+}

--- a/core/WsjtxUDPReceiver.h
+++ b/core/WsjtxUDPReceiver.h
@@ -6,7 +6,7 @@
 #include <QHostAddress>
 #include <QSqlRecord>
 #include <QNetworkDatagram>
-
+#include "data/DxSpot.h"
 #include "data/UpdatableSQLRecord.h"
 
 class Data;
@@ -147,6 +147,7 @@ signals:
 public slots:
     void startReply(WsjtxDecode);
     void reloadSetting();
+    void dxSpot(const DxSpot&);
 
 private slots:
     void readPendingDatagrams();
@@ -158,7 +159,7 @@ private:
     QUdpSocket* socket;
     QHostAddress wsjtxAddress;
     quint16 wsjtxPort;
-
+    QList<DxSpot> dxData;
     UpdatableSQLRecord wsjtSQLRecord;
 
     static int DEFAULT_PORT;

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -322,7 +322,7 @@ MainWindow::MainWindow(QWidget* parent) :
     connect(ui->dxWidget, &DxWidget::newToAllSpot, &networknotification, &NetworkNotification::toAllSpot);
     connect(ui->dxWidget, &DxWidget::tuneDx, ui->newContactWidget, &NewContactWidget::tuneDx);
     connect(ui->dxWidget, &DxWidget::tuneBand, ui->rigWidget, &RigWidget::setBand);
-
+    connect(ui->dxWidget, &DxWidget::newSpot, wsjtx, &WsjtxUDPReceiver::dxSpot);
     connect(&alertEvaluator, &AlertEvaluator::spotAlert, this, &MainWindow::processSpotAlert);
     connect(&alertEvaluator, &AlertEvaluator::spotAlert, &networknotification, &NetworkNotification::spotAlert);
 


### PR DESCRIPTION
Search through DXSpots (filtered to FTx and DIGITAL) and if a callsign and frequency match +- 5 Khz  will update POTA, IOTA, SOTA or WWFF references if exists in a DXSpot entry.