### PR TITLE
Nearest spot updates

### DIFF
--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -454,6 +454,35 @@ void NewContactWidget::handleCallsignFromUser()
     clearCallbookQueryFields();
     clearMemberQueryFields();
 
+    if(callsign == ui->nearStationLabel->text() &&
+        ! ui->nearStationLabel->text().isEmpty() &&
+        ! callsign.isEmpty())
+    {
+        if (callsign == nearestSpot.callsign) // AA5SH
+        {
+            if (nearestSpot.containsPOTA)
+            {
+                uiDynamic->potaEdit->setText(nearestSpot.potaRef);
+                isPOTAValid(nullptr);
+            }
+            if (nearestSpot.containsSOTA)
+            {
+                uiDynamic->sotaEdit->setText(nearestSpot.sotaRef);
+                isSOTAValid(nullptr);
+            }
+            if (nearestSpot.containsIOTA)
+            {
+                uiDynamic->iotaEdit->setText(nearestSpot.iotaRef);
+            }
+            if (nearestSpot.containsWWFF)
+            {
+                uiDynamic->wwffEdit->setText(nearestSpot.wwffRef);
+                isWWFFValid(nullptr);
+            }
+        }
+    }
+
+
     if ( callsign.isEmpty() )
     {
         setDxccInfo(DxccEntity());

--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -458,7 +458,7 @@ void NewContactWidget::handleCallsignFromUser()
         ! ui->nearStationLabel->text().isEmpty() &&
         ! callsign.isEmpty())
     {
-        if (callsign == nearestSpot.callsign) // AA5SH
+        if (callsign == nearestSpot.callsign)
         {
             if (nearestSpot.containsPOTA)
             {


### PR DESCRIPTION
Added an option where when you utilize the close station completer for the callsign it will check to see if the near spot still matches and if it has POTA, SOTA, IOTA or WWFF it will add that to the new contact entries.