### PR TITLE
Add Heartbeat for Rig UDP Broadcast

### DIFF
--- a/QLog.pro
+++ b/QLog.pro
@@ -476,8 +476,8 @@ macx: {
       INSTALLS += target
    }
 
-   INCLUDEPATH += /usr/local/include /opt/homebrew/include
-   LIBS += -L/usr/local/lib -L/opt/homebrew/lib -lhamlib -lsqlite3
+   INCLUDEPATH += /usr/local/include /opt/homebrew/include /usr/local/include
+   LIBS += -L/usr/local/lib -L/opt/homebrew/lib -lhamlib -lsqlite3 -L/opt/local/lib
    equals(QT_MAJOR_VERSION, 6): LIBS += -lqt6keychain
    equals(QT_MAJOR_VERSION, 5): LIBS += -lqt5keychain
    DISTFILES +=

--- a/rig/Rig.cpp
+++ b/rig/Rig.cpp
@@ -50,6 +50,10 @@ Rig::Rig(QObject *parent)
                                          &FlrigRigDrv::getModelList,
                                          &FlrigRigDrv::getCaps,
                                          nullptr);
+    QTimer *heartBeatTimer = new QTimer(this);
+    connect(heartBeatTimer, &QTimer::timeout, this, &Rig::sendHeartBeat);
+    heartBeatTimer->start(1000);
+
 }
 
 qint32 Rig::getNormalBandwidth(const QString &mode, const QString &)
@@ -664,4 +668,12 @@ Rig::~Rig()
     __closeRig();
 }
 
+void Rig::sendHeartBeat()
+{
+    if (rigStatus.isConnected)
+    {
+     emitRigStatusChanged();
+    }
+
+}
 #undef MUTEXLOCKER

--- a/rig/Rig.h
+++ b/rig/Rig.h
@@ -134,6 +134,7 @@ private slots:
     void stopMorseImpl();
     void sendStateImpl();
     void sendDXSpotImpl(const DxSpot &spot);
+    void sendHeartBeat();
 
 private:
     class DrvParams


### PR DESCRIPTION
I created an application for my Steppir to monitor the Network Broadcast.  But it doesn't send unless the frequency is changed.  Often I may start the application up after QLog so it never gets a frequency.  I thought it would be useful to send a periodic heartbeat if the radio is connected.  That way anything that is monitoring for the UPD broadcasts it would get it and stay in sync.  Also sense UDP isn't guaranteed this would help if the broad cast is missed.