### PR TITLE
rigctld server

### DIFF
--- a/QLog.pro
+++ b/QLog.pro
@@ -110,6 +110,7 @@ SOURCES += \
         rig/drivers/GenericRigDrv.cpp \
         rig/drivers/HamlibRigDrv.cpp \
         rig/drivers/TCIRigDrv.cpp \
+        rig/rigctldmanager.cpp \
         rotator/RotCaps.cpp \
         rotator/Rotator.cpp \
         rotator/drivers/GenericRotDrv.cpp \
@@ -252,6 +253,7 @@ HEADERS += \
         rig/drivers/HamlibRigDrv.h \
         rig/drivers/TCIRigDrv.h \
         rig/macros.h \
+        rig/rigctldmanager.h \
         rotator/RotCaps.h \
         rotator/Rotator.h \
         rotator/drivers/GenericRotDrv.h \
@@ -476,8 +478,32 @@ macx: {
       INSTALLS += target
    }
 
-   INCLUDEPATH += /usr/local/include /opt/homebrew/include
-   LIBS += -L/usr/local/lib -L/opt/homebrew/lib -lhamlib -lsqlite3
+    RIGCTLD_PATH =
+    RIGCTLD_CANDIDATES = \
+        /opt/homebrew/bin/rigctld \        # Apple Silicon Homebrew
+        /usr/local/bin/rigctld \           # Intel Homebrew or older setups
+        $$HOME/bin/rigctld \               # user bin
+        $$PWD/third_party/rigctld          # project-local copy (if you keep one)
+
+    for (c, RIGCTLD_CANDIDATES) {
+        exists($$c) {
+            RIGCTLD_PATH = $$c
+            break()
+        }
+    }
+
+    !isEmpty(RIGCTLD_PATH) {
+        message(Embedding rigctld from: $$RIGCTLD_PATH)
+        rigctld.files = $$RIGCTLD_PATH
+        rigctld.path  = Contents/MacOS      # put next to your app binary
+        QMAKE_BUNDLE_DATA += rigctld
+    } else {
+        message(rigctld not found; not embedding)
+    }
+
+
+   INCLUDEPATH += /usr/local/include /opt/homebrew/include /opt/local/include
+   LIBS += -L/usr/local/lib -L/opt/homebrew/lib -lhamlib -lsqlite3 -L/opt/local/lib
    equals(QT_MAJOR_VERSION, 6): LIBS += -lqt6keychain
    equals(QT_MAJOR_VERSION, 5): LIBS += -lqt5keychain
    DISTFILES +=

--- a/core/Migration.h
+++ b/core/Migration.h
@@ -42,7 +42,7 @@ private:
     QString fixIntlField(QSqlQuery &query, const QString &columName, const QString &columnNameIntl);
     bool refreshUploadStatusTrigger();
 
-    static const int latestVersion = 34;
+    static const int latestVersion = 35;
 };
 
 #endif // QLOG_CORE_MIGRATION_H

--- a/data/RigProfile.cpp
+++ b/data/RigProfile.cpp
@@ -19,7 +19,8 @@ QDataStream& operator<<(QDataStream& out, const RigProfile& v)
         << v.xitOffset << v.getRITInfo << v.getXITInfo
         << v.defaultPWR << v.getPTTInfo << v.QSYWiping
         << v.getKeySpeed << v.assignedCWKey << v.keySpeedSync
-        << v.driver << v.dxSpot2Rig << v.pttType << v.pttPortPath;
+        << v.driver << v.dxSpot2Rig << v.pttType << v.pttPortPath
+        << v.use_rigctld << v.use_rigctld_debug;
 
     return out;
 }
@@ -57,6 +58,8 @@ QDataStream& operator>>(QDataStream& in, RigProfile& v)
     in >> v.dxSpot2Rig;
     in >> v.pttType;
     in >> v.pttPortPath;
+    in >> v.use_rigctld;
+    in >> v.use_rigctld_debug;
 
     return in;
 }
@@ -73,7 +76,8 @@ RigProfilesManager::RigProfilesManager() :
                                 "pollinterval, txfreq_start, txfreq_end, get_freq, get_mode, "
                                 "get_vfo, get_pwr, rit_offset, xit_offset, get_rit, get_xit, "
                                 "default_pwr, get_ptt, qsy_wiping, get_key_speed, assigned_cw_key, "
-                                "key_speed_sync, driver, dxspot2rig, ptt_type, ptt_port_pathname "
+                                "key_speed_sync, driver, dxspot2rig, ptt_type, ptt_port_pathname, "
+                                "use_rigctld, use_rigctld_debug "
                                 "FROM rig_profiles") )
     {
         qWarning()<< "Cannot prepare select";
@@ -115,7 +119,8 @@ RigProfilesManager::RigProfilesManager() :
             profileDB.dxSpot2Rig = profileQuery.value(28).toBool();
             profileDB.pttType = profileQuery.value(29).toString();
             profileDB.pttPortPath = profileQuery.value(30).toString();
-
+            profileDB.use_rigctld = profileQuery.value(31).toBool();
+            profileDB.use_rigctld_debug = profileQuery.value(32).toBool();
             addProfile(profileDB.profileName, profileDB);
         }
     }
@@ -142,12 +147,12 @@ void RigProfilesManager::save()
                                "baudrate, databits, stopbits, flowcontrol, parity, pollinterval, txfreq_start, "
                                "txfreq_end, get_freq, get_mode, get_vfo, get_pwr, rit_offset, xit_offset, get_rit, "
                                "get_xit, default_pwr, get_ptt, qsy_wiping, get_key_speed, assigned_cw_key, key_speed_sync, "
-                               "driver, dxSpot2Rig, ptt_type, ptt_port_pathname ) "
+                               "driver, dxSpot2Rig, ptt_type, ptt_port_pathname, use_rigctld, use_rigctld_debug ) "
                         "VALUES (:profile_name, :model, :port_pathname, :hostname, :netport, "
                                ":baudrate, :databits, :stopbits, :flowcontrol, :parity, :pollinterval, :txfreq_start, "
                                ":txfreq_end, :get_freq, :get_mode, :get_vfo, :get_pwr, :rit_offset, :xit_offset, :get_rit, "
                                ":get_xit, :default_pwr, :get_ptt, :qsy_wiping, :get_key_speed, :assigned_cw_key, :key_speed_sync, "
-                               ":driver, :dxSpot2Rig, :ptt_type, :ptt_port_pathname)") )
+                               ":driver, :dxSpot2Rig, :ptt_type, :ptt_port_pathname, :use_rigctld, :use_rigctld_debug )") )
     {
         qWarning() << "cannot prepare Insert statement";
         return;
@@ -191,6 +196,8 @@ void RigProfilesManager::save()
             insertQuery.bindValue(":dxSpot2Rig", rigProfile.dxSpot2Rig);
             insertQuery.bindValue(":ptt_type", rigProfile.pttType);
             insertQuery.bindValue(":ptt_port_pathname", rigProfile.pttPortPath);
+            insertQuery.bindValue(":use_rigctld",rigProfile.use_rigctld);
+            insertQuery.bindValue(":use_rigctld_debug",rigProfile.use_rigctld_debug);
 
             if ( ! insertQuery.exec() )
             {
@@ -239,6 +246,8 @@ bool RigProfile::operator==(const RigProfile &profile)
             && profile.dxSpot2Rig == this->dxSpot2Rig
             && profile.pttType == this->pttType
             && profile.pttPortPath == this->pttPortPath
+            && profile.use_rigctld == this->use_rigctld
+            && profile.use_rigctld_debug == this->use_rigctld_debug
             );
 }
 

--- a/data/RigProfile.h
+++ b/data/RigProfile.h
@@ -29,7 +29,7 @@ public:
                    ritOffset = 0.0; xitOffset = 0.0, getRITInfo = false;
                    getXITInfo = true; defaultPWR = 0.0, getPTTInfo = false;
                    QSYWiping = false, getKeySpeed = false, keySpeedSync = false;
-                   driver = 0, dxSpot2Rig = false;
+                   driver = 0, dxSpot2Rig = false, use_rigctld = false, use_rigctld_debug = false;
                  };
 
     QString profileName;
@@ -63,6 +63,8 @@ public:
     bool dxSpot2Rig;
     QString pttType;
     QString pttPortPath;
+    bool use_rigctld;
+    bool use_rigctld_debug;
 
     bool operator== (const RigProfile &profile);
     bool operator!= (const RigProfile &profile);

--- a/res/res.qrc
+++ b/res/res.qrc
@@ -47,5 +47,6 @@
         <file>sql/migration_032.sql</file>
         <file>sql/migration_033.sql</file>
         <file>sql/migration_034.sql</file>
+        <file>sql/migration_035.sql</file>
     </qresource>
 </RCC>

--- a/res/sql/migration_035.sql
+++ b/res/sql/migration_035.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rig_profiles ADD use_rigctld INTEGER DEFAULT 0;
+ALTER TABLE rig_profiles ADD use_rigctld_debug INTEGER DEFAULT 0;

--- a/rig/drivers/HamlibRigDrv.cpp
+++ b/rig/drivers/HamlibRigDrv.cpp
@@ -158,8 +158,8 @@ HamlibRigDrv::HamlibRigDrv(const RigProfile &profile,
         lastErrorText = tr("Initialization Error");
     }
 
-    rigctld_ = std::make_unique<RigctldManager>(this);
-
+   // rigctld_ = std::make_unique<RigctldManager>(this);
+    rigctld_.reset(new RigctldManager(this));
     rig_set_debug(RIG_DEBUG_BUG);
 
     connect(&errorTimer, &QTimer::timeout,

--- a/rig/drivers/HamlibRigDrv.cpp
+++ b/rig/drivers/HamlibRigDrv.cpp
@@ -5,6 +5,7 @@
 #include "core/debug.h"
 #include "rig/macros.h"
 #include "data/SerialPort.h"
+#include "rig/rigctldmanager.h"
 
 #ifndef HAMLIB_FILPATHLEN
 #define HAMLIB_FILPATHLEN FILPATHLEN
@@ -157,6 +158,8 @@ HamlibRigDrv::HamlibRigDrv(const RigProfile &profile,
         lastErrorText = tr("Initialization Error");
     }
 
+    rigctld_ = std::make_unique<RigctldManager>(this);
+
     rig_set_debug(RIG_DEBUG_BUG);
 
     connect(&errorTimer, &QTimer::timeout,
@@ -172,6 +175,11 @@ HamlibRigDrv::~HamlibRigDrv()
         qCDebug(runtime) << "Waited too long";
         // better to make a memory leak
         return;
+    }
+
+    if (rigctld_)
+    {
+        rigctld_->stop();
     }
 
     if ( rig )
@@ -198,52 +206,93 @@ bool HamlibRigDrv::open()
     }
 
     RigProfile::rigPortType portType = rigProfile.getPortType();
+    rigctld_->setDebugLogsEnabled(rigProfile.use_rigctld_debug);
 
-    if ( portType == RigProfile::NETWORK_ATTACHED )
+    QString err;
+    const QString rigctldPath = rigctld_->findRigctldExecutable();
+
+    if (!rigctldPath.isEmpty() &&
+        rigProfile.use_rigctld)
     {
-        //handling Network Radio
-        const QString portString = rigProfile.hostname + ":" + QString::number(rigProfile.netport);
+        if(!rigctld_->startFromProfile(rigProfile, 4532, rigctldPath, &err))
+        {
+            qWarning() << "Couldn't Launch RigCtlD";
+            return false;
+        }
+        qCDebug(runtime) << "rigctld started; switching to NETRIGCTL model";
+
+        // 1) Dispose of the rig initialized with the hardware model
+        rig_close(rig);          // safe even if not opened yet
+        rig_cleanup(rig);
+        rig = nullptr;
+
+        // 2) Re-init as NETRIGCTL (hamlib model 2)
+        rig = rig_init(RIG_MODEL_NETRIGCTL);
+
+        if (!rig) {
+            lastErrorText = tr("Initialization Error (NETRIGCTL)");
+            qCDebug(runtime) << "Cannot allocate NET rig structure";
+            return false;
+        }
+
+        // optional: keep your debug level
+        rig_set_debug(RIG_DEBUG_BUG);
+
+        // 3) Point NETRIG to local rigctld
+        QString portString =  "127.0.0.1:" + QString::number(rigctld_->listenPort());
         strncpy(rig->state.rigport.pathname, portString.toLocal8Bit().constData(), HAMLIB_FILPATHLEN - 1);
-    }
-    else if ( portType == RigProfile::SERIAL_ATTACHED )
-    {
-        //handling Serial Port Radio
-        strncpy(rig->state.rigport.pathname, rigProfile.portPath.toLocal8Bit().constData(), HAMLIB_FILPATHLEN - 1);
-        rig->state.rigport.parm.serial.rate = rigProfile.baudrate;
-        rig->state.rigport.parm.serial.data_bits = rigProfile.databits;
-        rig->state.rigport.parm.serial.stop_bits = rigProfile.stopbits;
-        rig->state.rigport.parm.serial.handshake = stringToHamlibFlowControl(rigProfile.flowcontrol);
-        rig->state.rigport.parm.serial.parity = stringToHamlibParity(rigProfile.parity);
 
-        qCDebug(runtime) << "Using PTT Type" << rigProfile.pttType.toLocal8Bit().constData()
-                         << "PTT Path" << rigProfile.pttPortPath;
-
-        if ( !rigProfile.pttPortPath.isEmpty() )
-        {
-            strncpy(PTTPORT(rig)->pathname, rigProfile.pttPortPath.toLocal8Bit().constData(), HAMLIB_FILPATHLEN - 1);
-        }
-
-        if ( rig_set_conf(rig, rig_token_lookup(rig, "ptt_type"), rigProfile.pttType.toLocal8Bit().constData()) != RIG_OK )
-        {
-            lastErrorText = tr("Cannot set PTT Type");
-            qCDebug(runtime) << "Rig Open Error" << lastErrorText;
-            return false;
-        }
-
-        if ( rig_set_conf(rig, rig_token_lookup(rig, "ptt_share"), "1") != RIG_OK )
-        {
-            lastErrorText = tr("Cannot set PTT Share");
-            qCDebug(runtime) << "Rig Open Error" << lastErrorText;
-            return false;
-        }
+        // From here down, treat it like a network-attached rig
+        // (skip the hardware serial config branch entirely)
+        portType = RigProfile::NETWORK_ATTACHED;
     }
     else
     {
-        lastErrorText = tr("Unsupported Rig Driver");
-        qCDebug(runtime) << "Rig Open Error" << lastErrorText;
-        return false;
-    }
+        if ( portType == RigProfile::NETWORK_ATTACHED )
+        {
+            //handling Network Radio
+            const QString portString = rigProfile.hostname + ":" + QString::number(rigProfile.netport);
+            strncpy(rig->state.rigport.pathname, portString.toLocal8Bit().constData(), HAMLIB_FILPATHLEN - 1);
+        }
+        else if ( portType == RigProfile::SERIAL_ATTACHED )
+        {
+            //handling Serial Port Radio
+            strncpy(rig->state.rigport.pathname, rigProfile.portPath.toLocal8Bit().constData(), HAMLIB_FILPATHLEN - 1);
+            rig->state.rigport.parm.serial.rate = rigProfile.baudrate;
+            rig->state.rigport.parm.serial.data_bits = rigProfile.databits;
+            rig->state.rigport.parm.serial.stop_bits = rigProfile.stopbits;
+            rig->state.rigport.parm.serial.handshake = stringToHamlibFlowControl(rigProfile.flowcontrol);
+            rig->state.rigport.parm.serial.parity = stringToHamlibParity(rigProfile.parity);
 
+            qCDebug(runtime) << "Using PTT Type" << rigProfile.pttType.toLocal8Bit().constData()
+                             << "PTT Path" << rigProfile.pttPortPath;
+
+            if ( !rigProfile.pttPortPath.isEmpty() )
+            {
+                strncpy(PTTPORT(rig)->pathname, rigProfile.pttPortPath.toLocal8Bit().constData(), HAMLIB_FILPATHLEN - 1);
+            }
+
+            if ( rig_set_conf(rig, rig_token_lookup(rig, "ptt_type"), rigProfile.pttType.toLocal8Bit().constData()) != RIG_OK )
+            {
+                lastErrorText = tr("Cannot set PTT Type");
+                qCDebug(runtime) << "Rig Open Error" << lastErrorText;
+                return false;
+            }
+
+            if ( rig_set_conf(rig, rig_token_lookup(rig, "ptt_share"), "1") != RIG_OK )
+            {
+                lastErrorText = tr("Cannot set PTT Share");
+                qCDebug(runtime) << "Rig Open Error" << lastErrorText;
+                return false;
+            }
+        }
+        else
+        {
+            lastErrorText = tr("Unsupported Rig Driver");
+            qCDebug(runtime) << "Rig Open Error" << lastErrorText;
+            return false;
+        }
+  }
     int status = rig_open(rig);
 
     if ( !isRigRespOK(status, tr("Rig Open Error"), false) )

--- a/rig/drivers/HamlibRigDrv.h
+++ b/rig/drivers/HamlibRigDrv.h
@@ -7,6 +7,7 @@
 
 #include "GenericRigDrv.h"
 #include "rig/RigCaps.h"
+#include "rig/rigctldmanager.h"
 
 class HamlibRigDrv : public GenericRigDrv
 {
@@ -76,7 +77,7 @@ private:
     serial_handshake_e stringToHamlibFlowControl(const QString &in_flowcontrol);
     serial_parity_e stringToHamlibParity(const QString &in_parity);
     QString hamlibErrorString(int);
-
+    std::unique_ptr<RigctldManager> rigctld_;
     RIG* rig;
     QTimer timer;
     QTimer errorTimer;

--- a/rig/rigctldmanager.cpp
+++ b/rig/rigctldmanager.cpp
@@ -1,0 +1,225 @@
+// RigctldManager.cpp
+#include "rigctldmanager.h"
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QCoreApplication>
+#include <QThread> // for msleep in the polling loop
+#include <QFile>
+#include <QTextStream>
+#include <QStandardPaths>
+#include <QDir>
+#include <QDateTime>
+#include "core/debug.h"
+
+MODULE_IDENTIFICATION("qlog.rig.rigctldmanager");
+
+static QString rigLogPath() {
+    FCT_IDENTIFICATION;
+
+    const QString base = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir().mkpath(base + "/logs");
+    const QString stamp = QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss");
+    return base + "/logs/rigctld_" + stamp + ".log";
+}
+
+void RigctldManager::appendToRigctldLog(const QString& s) {
+    FCT_IDENTIFICATION;
+
+    if (!debugLogs_) return;
+    if (logPath_.isEmpty()) {
+        logPath_ = rigLogPath();
+        proc_.setStandardOutputFile(logPath_, QIODevice::Append);
+        proc_.setStandardErrorFile(logPath_, QIODevice::Append);
+    }
+    QFile f(logPath_);
+    if (f.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+        QTextStream ts(&f);
+        ts << s;
+    }
+}
+
+bool RigctldManager::isTcpPortOpen(const QHostAddress& host, quint16 port, int timeoutMs) {
+    FCT_IDENTIFICATION;
+
+    QTcpSocket s;
+    s.connectToHost(host, port);
+    return s.waitForConnected(timeoutMs);
+}
+
+quint16 RigctldManager::findFreePort(quint16 preferred) {
+    FCT_IDENTIFICATION;
+
+    QTcpServer s;
+    if (preferred && s.listen(QHostAddress::LocalHost, preferred)) return preferred;
+    if (s.listen(QHostAddress::LocalHost, 0)) return s.serverPort();
+    return 0;
+}
+
+RigctldManager::RigctldManager(QObject* parent) : QObject(parent) {
+    FCT_IDENTIFICATION;
+
+    proc_.setProcessChannelMode(QProcess::SeparateChannels);
+
+    connect(&proc_, &QProcess::readyReadStandardOutput, this, [this]{
+        const auto chunk = QString::fromLocal8Bit(proc_.readAllStandardOutput());
+        emit rigctldOutput(chunk);
+        appendToRigctldLog(chunk);
+    });
+    connect(&proc_, &QProcess::readyReadStandardError, this, [this]{
+        const auto chunk = QString::fromLocal8Bit(proc_.readAllStandardError());
+        emit rigctldError(chunk);
+        appendToRigctldLog(chunk);
+    });
+
+    connect(&proc_, &QProcess::errorOccurred, this, [this](QProcess::ProcessError e){
+        appendToRigctldLog(QStringLiteral("QProcess error: %1\n").arg(int(e)));
+    });
+    connect(&proc_, QOverload<int,QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this](int code, QProcess::ExitStatus st){
+                appendToRigctldLog(QStringLiteral("rigctld finished: exitCode=%1, exitStatus=%2\n")
+                                       .arg(code).arg(st==QProcess::NormalExit ? "Normal" : "Crashed"));
+                emit rigctldExited(code, st);
+            });
+}
+
+bool RigctldManager::startFromProfile(const RigProfile& prof,
+                                      quint16 preferPort,
+                                      QString rigctldPath,
+                                      QString* err) {
+    FCT_IDENTIFICATION;
+
+    if (isRunning()) return true;
+
+    port_ = findFreePort(preferPort ? preferPort : 4532);
+    if (!port_) { if (err) *err = "No free TCP port for rigctld."; return false; }
+
+    if (isTcpPortOpen(QHostAddress::LocalHost, port_)) {
+        appendToRigctldLog(QStringLiteral("Reusing existing server on %1\n").arg(port_));
+        return true;
+    }
+
+    QStringList args = buildRigctldArgs(prof, port_);
+    if (debugLogs_) { args << "-vvvv"; }
+
+    appendToRigctldLog(QStringLiteral("Launching: %1 %2\n")
+                           .arg(rigctldPath, args.join(' ')));
+
+    proc_.setProgram(rigctldPath);
+    proc_.setArguments(args);
+
+    proc_.start();
+    if (!proc_.waitForStarted(5000)) {
+        if (err) *err = "Failed to start rigctld (path/signature issue?).";
+        appendToRigctldLog(*err + "\n");
+        return false;
+    }
+
+    const int maxWaitMs = 5000, stepMs = 100;
+    int waited = 0;
+    while (waited < maxWaitMs) {
+        if (isTcpPortOpen(QHostAddress::LocalHost, port_)) {
+            appendToRigctldLog(QStringLiteral("rigctld is listening on 127.0.0.1:%1\n").arg(port_));
+            return true;
+        }
+        QThread::msleep(stepMs);
+        waited += stepMs;
+
+        if (proc_.state() != QProcess::Running) {
+            if (err) *err = "rigctld exited before it became ready.";
+            appendToRigctldLog(*err + "\n");
+            return false;
+        }
+    }
+
+    if (err) *err = "rigctld did not open its TCP port in time.";
+    appendToRigctldLog(*err + "\n");
+    return false;
+}
+
+void RigctldManager::stop() {
+    FCT_IDENTIFICATION;
+
+    if (!isRunning()) return;
+    proc_.terminate();
+    if (!proc_.waitForFinished(2000)) {
+        proc_.kill();
+        proc_.waitForFinished(2000);
+    }
+}
+
+QString RigctldManager::normalizeParity(const QString& p) {
+    FCT_IDENTIFICATION;
+
+    const QString v = p.trimmed().toLower();
+    if (v == "even") return "Even";
+    if (v == "odd")  return "Odd";
+    return "None";
+}
+
+QString RigctldManager::normalizeHandshake(const QString& s) {
+    FCT_IDENTIFICATION;
+
+    const QString v = s.trimmed().toLower();
+    if (v == "hardware" || v == "rtscts") return "Hardware";
+    if (v == "software" || v == "xonxoff") return "Software";
+    return "None";
+}
+
+QStringList RigctldManager::buildRigctldArgs(const RigProfile& rigProfile, quint16 tcpPortToServeOn) {
+    FCT_IDENTIFICATION;
+
+    QStringList args;
+
+    RigProfile::rigPortType portType = rigProfile.getPortType();
+
+    args << "-m" << QString::number(rigProfile.model);
+    args << "-p" << QString::number(tcpPortToServeOn);
+
+
+    if (portType == RigProfile::NETWORK_ATTACHED)
+    {
+        args << "-r" << QString("%1:%2").arg(rigProfile.hostname).arg(rigProfile.netport);
+    }
+    else if (portType == RigProfile::SERIAL_ATTACHED)
+    {
+        args << "-r" << rigProfile.portPath.toLocal8Bit().constData();
+        args << "-s" << QString::number(rigProfile.baudrate);
+        args << "-C" << QString("stop_bits=%1").arg(rigProfile.stopbits);
+        args << "-C" << QString("data_bits=%1").arg(rigProfile.databits);
+        args << "-C" << QString("serial_handshake=%1").arg(normalizeHandshake(rigProfile.flowcontrol));
+        args << "-C" << QString("parity=%1").arg(rigProfile.parity);
+
+        if ( !rigProfile.pttPortPath.isEmpty() )
+        {
+            args << "-p" << rigProfile.pttPortPath.toLocal8Bit().constData();
+        }
+    }
+
+    return args;
+}
+
+QString RigctldManager::findRigctldExecutable() {
+    FCT_IDENTIFICATION;
+
+#ifdef Q_OS_MAC
+    // bundled next to the main binary
+    const QString bundled = QCoreApplication::applicationDirPath() + "/rigctld";
+#elif defined(Q_OS_WIN)
+    const QString bundled = QCoreApplication::applicationDirPath() + "/rigctld.exe";
+#else
+    const QString bundled = QCoreApplication::applicationDirPath() + "/rigctld";
+#endif
+    if (QFileInfo::exists(bundled) && QFileInfo(bundled).isExecutable())
+        return bundled;
+
+    // fallback: search PATH
+    const QString rigctld = QStandardPaths::findExecutable(
+#ifdef Q_OS_WIN
+        "rigctld.exe"
+#else
+        "rigctld"
+#endif
+        );
+    return rigctld; // may be empty if not found
+}
+

--- a/rig/rigctldmanager.h
+++ b/rig/rigctldmanager.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <QObject>
+#include <QProcess>
+#include <QTcpServer>
+#include "data/RigProfile.h"
+#include "hamlib/rig.h"
+
+#ifndef RIGCTLDMANAGER_H
+#define RIGCTLDMANAGER_H
+
+class RigctldManager : public QObject {
+    Q_OBJECT
+public:
+    explicit RigctldManager(QObject* parent=nullptr);
+
+    bool startFromProfile(const RigProfile& prof,
+                          quint16 preferPort,  // e.g. 4532; 0 = auto
+                          QString rigctldPath, // resolved path (bundle or user setting)
+                          QString* errorOut = nullptr);
+
+    void stop();
+    bool isRunning() const { return proc_.state() == QProcess::Running; }
+    quint16 listenPort() const { return port_; }
+    QString findRigctldExecutable();
+    void setDebugLogsEnabled(bool v) {debugLogs_ = v;}
+
+signals:
+    void rigctldOutput(QString);
+    void rigctldError(QString);
+    void rigctldExited(int, QProcess::ExitStatus);
+
+    // RigctldManager.h (only the private section shown)
+private:
+    static bool isTcpPortOpen(const QHostAddress& host, quint16 port, int timeoutMs = 250);
+    static quint16 findFreePort(quint16 preferred);
+    static QStringList buildRigctldArgs(const RigProfile& p, quint16 tcpPortToServeOn);
+    static QString normalizeParity(const QString& p);
+    static QString normalizeHandshake(const QString& s);
+
+    QProcess proc_;
+    quint16  port_ = 0;
+    // RigctldManager.h (private:)
+    void appendToRigctldLog(const QString& s);
+    QString logPath_;
+    bool debugLogs_ = true;
+};
+
+#endif // RIGCTLDMANAGER_H

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -493,7 +493,8 @@ void SettingsDialog::addRigProfile()
     profile.getKeySpeed = ui->rigGetKeySpeedCheckBox->isChecked();
     profile.keySpeedSync = ui->rigKeySpeedSyncCheckBox->isChecked();
     profile.dxSpot2Rig = ui->rigDXSpots2RigCheckBox->isChecked();
-
+    profile.use_rigctld = ui->rigRigCtlDLauncher->isChecked();
+    profile.use_rigctld_debug = ui->rigRigCtlDLoggig->isChecked();
     rigProfManager->addProfile(profile.profileName, profile);
 
     refreshRigProfilesView();
@@ -569,6 +570,8 @@ void SettingsDialog::doubleClickRigProfile(QModelIndex i)
     ui->rigGetKeySpeedCheckBox->setChecked(profile.getKeySpeed);
     ui->rigKeySpeedSyncCheckBox->setChecked(profile.keySpeedSync);
     ui->rigDXSpots2RigCheckBox->setChecked(profile.dxSpot2Rig);
+    ui->rigRigCtlDLauncher->setChecked(profile.use_rigctld);
+    ui->rigRigCtlDLoggig->setChecked(profile.use_rigctld_debug);
 
     int flowControlIndex = ui->rigFlowControlSelect->findData(profile.flowcontrol.toLower());
     ui->rigFlowControlSelect->setCurrentIndex((flowControlIndex < 0) ? 0 : flowControlIndex);
@@ -583,6 +586,7 @@ void SettingsDialog::doubleClickRigProfile(QModelIndex i)
     ui->rigPTTPortEdit->setText(profile.pttPortPath);
 
     setUIBasedOnRigCaps(caps);
+    qWarning() << "rigctl checked" << ui->rigRigCtlDLauncher->checkState();
 
     ui->rigAddProfileButton->setText(tr("Modify"));
 }
@@ -623,6 +627,8 @@ void SettingsDialog::clearRigProfileForm()
     ui->rigGetKeySpeedCheckBox->setChecked(true);
     ui->rigKeySpeedSyncCheckBox->setChecked(false);
     ui->rigDXSpots2RigCheckBox->setChecked(false);
+    ui->rigRigCtlDLauncher->setChecked(false);
+    ui->rigRigCtlDLoggig->setChecked(false);
     ui->rigAddProfileButton->setText(tr("Add"));
     ui->rigPTTPortEdit->clear();
 }
@@ -1761,6 +1767,12 @@ void SettingsDialog::rigChanged(int index)
     ui->rigDXSpots2RigCheckBox->setEnabled(true);
     ui->rigDXSpots2RigCheckBox->setChecked(false);
 
+    ui->rigRigCtlDLauncher->setEnabled(true);
+    ui->rigRigCtlDLauncher->setChecked(false);
+
+    ui->rigRigCtlDLoggig->setEnabled(true);
+    ui->rigRigCtlDLoggig->setChecked(false);
+
     setUIBasedOnRigCaps(caps);
 }
 
@@ -2596,6 +2608,19 @@ void SettingsDialog::setUIBasedOnRigCaps(const RigCaps &caps)
     {
         ui->rigDXSpots2RigCheckBox->setEnabled(false);
         ui->rigDXSpots2RigCheckBox->setChecked(false);
+    }
+
+    if ( ui->rigInterfaceCombo->currentText() != "Hamlib")
+    {
+        ui->rigRigCtlDLauncher->setChecked(false);
+        ui->rigRigCtlDLauncher->setEnabled(false);
+        ui->rigRigCtlDLoggig->setChecked(false);
+        ui->rigRigCtlDLoggig->setEnabled(false);
+    }
+    else
+    {
+        ui->rigRigCtlDLauncher->setEnabled(true);
+        ui->rigRigCtlDLoggig->setEnabled(true);
     }
 
     if ( ui->rigAssignedCWKeyCombo->currentText() != EMPTY_CWKEY_PROFILE )

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -2324,6 +2324,27 @@
                    <widget class="QWidget" name="page"/>
                   </widget>
                  </item>
+                 <item row="22" column="1">
+                  <layout class="QHBoxLayout" name="horizontalLayout_4">
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QCheckBox" name="rigRigCtlDLauncher">
+                     <property name="text">
+                      <string>Launch rigctld</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="rigRigCtlDLoggig">
+                     <property name="text">
+                      <string>Debug Logging</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
                  <item row="12" column="1">
                   <layout class="QHBoxLayout" name="horizontalLayout_4">
                    <property name="bottomMargin">
@@ -4665,6 +4686,8 @@
   <tabstop>rotParitySelect</tabstop>
   <tabstop>rotHostNameEdit</tabstop>
   <tabstop>rotNetPortSpin</tabstop>
+  <tabstop>rigRigCtlDLauncher</tabstop>
+  <tabstop>rigRigCtlDLoggig</tabstop>
   <tabstop>rotAddProfileButton</tabstop>
   <tabstop>rotDelProfileButton</tabstop>
   <tabstop>rotUsrButtonProfileNameEdit</tabstop>


### PR DESCRIPTION
This is a modification for HamLib where if enebled it will take the rigprofile and launch an instance of rigctld then make a new rig instance to the rigctld server.  For MacOS it will copy rigctld executable to the app.  This an alternative to the DX Lab Commander Server.  I like this one better because it will future proof better with updates to hamlib and all.  

also has an option to dump rigctld to a log file.

<img width="766" height="821" alt="image" src="https://github.com/user-attachments/assets/42b54789-eecb-4e3d-91bf-4cf2ed2cac83" />
