### PR TITLE
Serial Port Completer

### DIFF
--- a/ui/component/EditLine.cpp
+++ b/ui/component/EditLine.cpp
@@ -97,6 +97,14 @@ SerialPortEditLine::SerialPortEditLine(QWidget *parent) :
         portNames << port.portName();
 
     setCompleter(new QCompleter(portNames));
+#elif defined(Q_OS_MAC)
+    QStringList portNames;
+    const QList<QSerialPortInfo> &ports = QSerialPortInfo::availablePorts();
+
+    for ( const QSerialPortInfo &port : ports )
+        portNames << QString("/dev/%1").arg(port.portName());
+
+    setCompleter(new QCompleter(portNames));
 #endif
 }
 
@@ -106,5 +114,9 @@ void SerialPortEditLine::focusInEvent(QFocusEvent *event)
 #if defined(Q_OS_WIN)
     completer()->setCompletionPrefix("COM");
     completer()->complete();
+#elif defined(Q_OS_WIN)
+    completer()->setCompletionPrefix("/dev/");
+    completer()->complete();
+
 #endif
 }


### PR DESCRIPTION
extended the serial port completer that was added for windows to work also for MacOS.

<img width="775" height="827" alt="image" src="https://github.com/user-attachments/assets/5c61d794-c2c6-420f-b6ec-87b193e7ea26" />
