### PR TITLE
Dock Widget missing tab

### DIFF
--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -90,6 +90,14 @@ MainWindow::MainWindow(QWidget* parent) :
 
     const QList<QDockWidget *> dockWidgets = findChildren<QDockWidget *>();
     for (QDockWidget *dockWidget : dockWidgets) {
+        if (!dockWidget)
+            continue;
+
+        // macOS only: keep floating tool windows always visible
+#ifdef Q_OS_MAC
+        dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
+#endif
+
         if (dockWidget)
             dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
     }


### PR DESCRIPTION
I needed to create a new database file and when I was setting up my screen the way I like it I noticed the tab panels were not showing properly.  I am not 100% sure if this is a Mac only issue but I blocked it that way just in case. 

In here should be Clock and Alerts
<img width="357" height="258" alt="Rule Name" src="https://github.com/user-attachments/assets/fec71471-5f25-4e50-9a13-dc33e27aacce" />

If I break it out they appear
<img width="350" height="209" alt="Rule Name" src="https://github.com/user-attachments/assets/45065739-cd1b-48e2-b87d-7d9ed720c682" />

This is how it looks after the patch:
<img width="365" height="239" alt="Rule Name" src="https://github.com/user-attachments/assets/6ba8556a-5087-4a82-89c1-92b2bac54f2a" />

