### PR TITLE
Dock Widget missing tab

### DIFF
--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -93,13 +93,13 @@ MainWindow::MainWindow(QWidget* parent) :
         if (!dockWidget)
             continue;
 
-        // macOS only: keep floating tool windows always visible
-#ifdef Q_OS_MAC
-        dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
-#endif
-
         if (dockWidget)
             dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
+
+        if (auto tabs = dockWidget->findChild<QTabWidget*>()) {
+            if (tabs->tabBar())
+                tabs->tabBar()->show();
+        }
     }
 
     const StationProfile &profile = StationProfilesManager::instance()->getCurProfile1();

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -90,6 +90,14 @@ MainWindow::MainWindow(QWidget* parent) :
 
     const QList<QDockWidget *> dockWidgets = findChildren<QDockWidget *>();
     for (QDockWidget *dockWidget : dockWidgets) {
+        if (!dockWidget)
+            continue;
+
+        // macOS only: keep floating tool windows always visible
+#ifdef Q_OS_MAC
+        dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
+#endif
+
         if (dockWidget)
             dockWidget->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
     }


### PR DESCRIPTION
I needed to create a new database file and when I was setting up my screen the way I like it I noticed the tab panels were not showing properly. I am not 100% sure if this is a Mac only issue but I blocked it that way just in case.

In here should be Clock and Alerts
<img width="366" height="266" alt="image" src="https://github.com/user-attachments/assets/6a1a1689-7fc4-4798-a584-b3b7c36747d3" />

If I break it out they appear
<img width="353" height="205" alt="image" src="https://github.com/user-attachments/assets/f856aa2f-875a-4f67-8c78-7ec3627b19e1" />

This is how it looks after the patch:
<img width="374" height="242" alt="image" src="https://github.com/user-attachments/assets/ea60c6fa-7682-4cac-a50f-fce49826de53" />