### PR TITLE
Add RTS and DTR control to rig profiles

### DIFF
--- a/core/Migration.h
+++ b/core/Migration.h
@@ -42,7 +42,7 @@ private:
     QString fixIntlField(QSqlQuery &query, const QString &columName, const QString &columnNameIntl);
     bool refreshUploadStatusTrigger();
 
-    static const int latestVersion = 34;
+    static const int latestVersion = 35;
 };
 
 #endif // QLOG_CORE_MIGRATION_H

--- a/data/RigProfile.cpp
+++ b/data/RigProfile.cpp
@@ -19,7 +19,8 @@ QDataStream& operator<<(QDataStream& out, const RigProfile& v)
         << v.xitOffset << v.getRITInfo << v.getXITInfo
         << v.defaultPWR << v.getPTTInfo << v.QSYWiping
         << v.getKeySpeed << v.assignedCWKey << v.keySpeedSync
-        << v.driver << v.dxSpot2Rig << v.pttType << v.pttPortPath;
+        << v.driver << v.dxSpot2Rig << v.pttType << v.pttPortPath
+        << v.rts << v.dtr;
 
     return out;
 }
@@ -57,6 +58,8 @@ QDataStream& operator>>(QDataStream& in, RigProfile& v)
     in >> v.dxSpot2Rig;
     in >> v.pttType;
     in >> v.pttPortPath;
+    in >> v.rts;
+    in >> v.dtr;
 
     return in;
 }
@@ -73,7 +76,8 @@ RigProfilesManager::RigProfilesManager() :
                                 "pollinterval, txfreq_start, txfreq_end, get_freq, get_mode, "
                                 "get_vfo, get_pwr, rit_offset, xit_offset, get_rit, get_xit, "
                                 "default_pwr, get_ptt, qsy_wiping, get_key_speed, assigned_cw_key, "
-                                "key_speed_sync, driver, dxspot2rig, ptt_type, ptt_port_pathname "
+                                "key_speed_sync, driver, dxspot2rig, ptt_type, ptt_port_pathname, "
+                                "rts, dtr "
                                 "FROM rig_profiles") )
     {
         qWarning()<< "Cannot prepare select";
@@ -115,6 +119,8 @@ RigProfilesManager::RigProfilesManager() :
             profileDB.dxSpot2Rig = profileQuery.value(28).toBool();
             profileDB.pttType = profileQuery.value(29).toString();
             profileDB.pttPortPath = profileQuery.value(30).toString();
+            profileDB.rts = profileQuery.value(31).toString();
+            profileDB.dtr = profileQuery.value(32).toString();
 
             addProfile(profileDB.profileName, profileDB);
         }
@@ -142,12 +148,12 @@ void RigProfilesManager::save()
                                "baudrate, databits, stopbits, flowcontrol, parity, pollinterval, txfreq_start, "
                                "txfreq_end, get_freq, get_mode, get_vfo, get_pwr, rit_offset, xit_offset, get_rit, "
                                "get_xit, default_pwr, get_ptt, qsy_wiping, get_key_speed, assigned_cw_key, key_speed_sync, "
-                               "driver, dxSpot2Rig, ptt_type, ptt_port_pathname ) "
+                               "driver, dxSpot2Rig, ptt_type, ptt_port_pathname, rts, dtr ) "
                         "VALUES (:profile_name, :model, :port_pathname, :hostname, :netport, "
                                ":baudrate, :databits, :stopbits, :flowcontrol, :parity, :pollinterval, :txfreq_start, "
                                ":txfreq_end, :get_freq, :get_mode, :get_vfo, :get_pwr, :rit_offset, :xit_offset, :get_rit, "
                                ":get_xit, :default_pwr, :get_ptt, :qsy_wiping, :get_key_speed, :assigned_cw_key, :key_speed_sync, "
-                               ":driver, :dxSpot2Rig, :ptt_type, :ptt_port_pathname)") )
+                               ":driver, :dxSpot2Rig, :ptt_type, :ptt_port_pathname, :rts, :dtr )") )
     {
         qWarning() << "cannot prepare Insert statement";
         return;
@@ -191,6 +197,9 @@ void RigProfilesManager::save()
             insertQuery.bindValue(":dxSpot2Rig", rigProfile.dxSpot2Rig);
             insertQuery.bindValue(":ptt_type", rigProfile.pttType);
             insertQuery.bindValue(":ptt_port_pathname", rigProfile.pttPortPath);
+            insertQuery.bindValue(":rts", rigProfile.rts);
+            insertQuery.bindValue(":dtr", rigProfile.dtr);
+
 
             if ( ! insertQuery.exec() )
             {
@@ -239,6 +248,8 @@ bool RigProfile::operator==(const RigProfile &profile)
             && profile.dxSpot2Rig == this->dxSpot2Rig
             && profile.pttType == this->pttType
             && profile.pttPortPath == this->pttPortPath
+            && profile.rts == this->rts
+            && profile.dtr == this->dtr
             );
 }
 

--- a/data/RigProfile.h
+++ b/data/RigProfile.h
@@ -63,6 +63,8 @@ public:
     bool dxSpot2Rig;
     QString pttType;
     QString pttPortPath;
+    QString rts;
+    QString dtr;
 
     bool operator== (const RigProfile &profile);
     bool operator!= (const RigProfile &profile);

--- a/res/res.qrc
+++ b/res/res.qrc
@@ -47,5 +47,6 @@
         <file>sql/migration_032.sql</file>
         <file>sql/migration_033.sql</file>
         <file>sql/migration_034.sql</file>
+        <file>sql/migration_035.sql</file>
     </qresource>
 </RCC>

--- a/res/sql/migration_035.sql
+++ b/res/sql/migration_035.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rig_profiles ADD COLUMN rts TEXT DEFAULT '';
+ALTER TABLE rig_profiles ADD COLUMN dtr TEXT DEFAULT '';

--- a/rig/drivers/HamlibRigDrv.cpp
+++ b/rig/drivers/HamlibRigDrv.cpp
@@ -217,6 +217,8 @@ bool HamlibRigDrv::open()
         rig->state.rigport.parm.serial.stop_bits = rigProfile.stopbits;
         rig->state.rigport.parm.serial.handshake = stringToHamlibFlowControl(rigProfile.flowcontrol);
         rig->state.rigport.parm.serial.parity = stringToHamlibParity(rigProfile.parity);
+        rig->state.rigport.parm.serial.dtr_state = stringToHamlibForceFlowControl(rigProfile.dtr);
+        rig->state.rigport.parm.serial.rts_state = stringToHamlibForceFlowControl(rigProfile.rts);
 
         qCDebug(runtime) << "Using PTT Type" << rigProfile.pttType.toLocal8Bit().constData()
                          << "PTT Path" << rigProfile.pttPortPath;
@@ -1148,6 +1150,21 @@ serial_parity_e HamlibRigDrv::stringToHamlibParity(const QString &in_parity)
 
     return RIG_PARITY_NONE;
 }
+
+serial_control_state_e HamlibRigDrv::stringToHamlibForceFlowControl(const QString &flowcontrol)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(function_parameters) << flowcontrol;
+
+    if (flowcontrol == "HIGH")
+        return RIG_SIGNAL_ON;
+    if (flowcontrol == "LOW")
+        return RIG_SIGNAL_OFF;
+
+    return RIG_SIGNAL_UNSET;
+}
+
 
 QString HamlibRigDrv::hamlibErrorString(int errorCode)
 {

--- a/rig/drivers/HamlibRigDrv.h
+++ b/rig/drivers/HamlibRigDrv.h
@@ -76,6 +76,7 @@ private:
     const QString hamlibVFO2String(const vfo_t vfo) const;
     serial_handshake_e stringToHamlibFlowControl(const QString &in_flowcontrol);
     serial_parity_e stringToHamlibParity(const QString &in_parity);
+    serial_control_state_e stringToHamlibForceFlowControl(const QString &flowcontrol);
     QString hamlibErrorString(int);
     RIG* rig;
     QTimer timer;

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -470,6 +470,8 @@ void SettingsDialog::addRigProfile()
         profile.parity = ui->rigParitySelect->currentData().toString();
         profile.pttType = ui->rigPTTTypeCombo->currentData().toString();
         profile.pttPortPath = ui->rigPTTPortEdit->text();
+        profile.rts = ui->cmbRigRTS->currentText();
+        profile.dtr = ui->cmbRigDTR->currentText();
     }
 
     if ( ui->rigPollIntervalSpinBox->isEnabled() )
@@ -581,6 +583,12 @@ void SettingsDialog::doubleClickRigProfile(QModelIndex i)
     int pttIndex = ui->rigPTTTypeCombo->findData(profile.pttType);
     ui->rigPTTTypeCombo->setCurrentIndex(( pttIndex < 0 ) ? PTT_TYPE_CAT_INDEX : pttIndex);
     ui->rigPTTPortEdit->setText(profile.pttPortPath);
+
+    int rtsIndex = ui->cmbRigRTS->findText(profile.rts);
+    ui->cmbRigRTS->setCurrentIndex(( rtsIndex < 0 ) ? PTT_TYPE_CAT_INDEX : rtsIndex);
+
+    int dtrIndex = ui->cmbRigDTR->findText(profile.dtr);
+    ui->cmbRigDTR->setCurrentIndex(( dtrIndex < 0 ) ? PTT_TYPE_CAT_INDEX : dtrIndex);
 
     setUIBasedOnRigCaps(caps);
 
@@ -726,11 +734,16 @@ void SettingsDialog::rigInterfaceChanged(int)
     ui->rigModelSelect->setCurrentIndex(( driverID == Rig::HAMLIB_DRIVER ) ? ui->rigModelSelect->findData(DEFAULT_HAMLIB_RIG_MODEL)
                                                                            : 0 );
     ui->rigPTTTypeCombo->clear();
+    ui->cmbRigRTS->setCurrentIndex(0);
+    ui->cmbRigDTR->setCurrentIndex(0);
 
     const QList<QPair<QString, QString>> &pttTypes = Rig::instance()->getPTTTypeList(static_cast<Rig::DriverID>(driverID));
 
     for ( const QPair<QString, QString> &type : pttTypes )
         ui->rigPTTTypeCombo->addItem(type.second, type.first);
+
+    ui->cmbRigRTS->setVisible((driverID == Rig::HAMLIB_DRIVER));
+    ui->cmbRigDTR->setVisible((driverID == Rig::HAMLIB_DRIVER));
 
     ui->rigPTTTypeCombo->setVisible(( driverID == Rig::HAMLIB_DRIVER ));
     ui->rigPTTTypeLabel->setVisible(( driverID == Rig::HAMLIB_DRIVER ));

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -2257,6 +2257,65 @@
                        </item>
                       </layout>
                      </item>
+                     <item row="7" column="0">
+                      <widget class="QLabel" name="rigFlowControlLines">
+                       <property name="text">
+                        <string>DTR</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="7" column="1">
+                      <layout class="QHBoxLayout" name="horizontalLayout_39">
+                       <item>
+                        <widget class="QComboBox" name="cmbRigDTR">
+                          <item>
+                            <property name="text">
+                            <string></string>
+                            </property>
+                          </item>
+                          <item>
+                            <property name="text">
+                            <string>High</string>
+                            </property>
+                          </item>
+                          <item>
+                            <property name="text">
+                            <string>Low</string>
+                            </property>
+                          </item>
+                       </widget>
+                       </item>
+                       <item>
+                        <widget class="QLabel" name="label_6">
+                         <property name="text">
+                          <string>RTS</string>
+                         </property>
+                         <property name="alignment">
+                          <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QComboBox" name="cmbRigRTS">              
+                          <item>
+                            <property name="text">
+                            <string></string>
+                            </property>
+                          </item>
+                          <item>
+                            <property name="text">
+                            <string>High</string>
+                            </property>
+                          </item>
+                          <item>
+                            <property name="text">
+                            <string>Low</string>
+                            </property>
+                          </item>
+                       </widget>
+                       </item>
+                      </layout>
+                     </item>
                     </layout>
                    </widget>
                    <widget class="QWidget" name="rigNetworkPage">


### PR DESCRIPTION
Introduces RTS and DTR fields to RigProfile, updates serialization, database schema, and UI to support these options. Hamlib driver now sets serial RTS/DTR states based on profile settings. Migration 035 adds the new columns to the database. #797 
<img width="767" height="830" alt="image" src="https://github.com/user-attachments/assets/2dde9712-dd84-4ffe-8d60-f988ad03c02f" />
