### PR TITLE
ui: Allow callbook lookups for WSJT-X contacts even without grid square

### DIFF
--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -2944,18 +2944,16 @@ void NewContactWidget::prepareWSJTXQSO(const QString &receivedCallsign,
     setDxccInfo(receivedCallsign);
     queryPota();
 
-    // at the moment WSJTX sends several statuses about changing one callsign.
-    // In order to avoid multiple searches, we will search only when we have a grid - it was usually the last
-    // status message
-    // the current status message sequence is
-    // 1) prev Callsign empty grid
-    // 2) new Callsign empty grid
-    // 3) new Calllsign, new gris
+    // Always trigger callbook lookup, even without grid square
+    // This enables lookups for WSJT-X compatible apps that don't provide grids
+    // CallbookManager has QCache caching to prevent redundant queries so this is safe
+    // it is needed for non WSJT-X content that we're accepting on the same port, such
+    // as WriteLog broadcast udp xml packets converted to ADIF.
     if ( !grid.isEmpty() )
     {
         useFieldsFromPrevQSO(callsign, grid);
-        finalizeCallsignEdit();
     }
+    finalizeCallsignEdit();
 }
 
 void NewContactWidget::setDefaultReport()


### PR DESCRIPTION
This change is to allow WSJT-X format broadcast packets to trigger a callbook lookup even when the grid square is not specified. This is useful for non FT8 content. For example, realtime contest logs being sent from WriteLog to Qlog via the WSJT-X protocol.  It is safe to call finalizeCallsignEdit() even without the grid square because the CallbookManager will cache lookups and prevent redundant lookups when WSJT-X sends multiple status type messages.