### PR TITLE
ui: Always do callbook lookups for WSJT-X packets from WRITELOG

### DIFF
--- a/ui/NewContactWidget.cpp
+++ b/ui/NewContactWidget.cpp
@@ -2915,11 +2915,12 @@ void NewContactWidget::fillCallsignGrid(const QString &callsign, const QString &
 }
 
 void NewContactWidget::prepareWSJTXQSO(const QString &receivedCallsign,
-                                       const QString &grid)
+                                       const QString &grid,
+                                       const QString &id)
 {
     FCT_IDENTIFICATION;
 
-    qCDebug(function_parameters) << receivedCallsign << grid;
+    qCDebug(function_parameters) << receivedCallsign << grid << id;
 
     if ( isManualEnterMode )
     {
@@ -2939,7 +2940,12 @@ void NewContactWidget::prepareWSJTXQSO(const QString &receivedCallsign,
 
     callsign = receivedCallsign;
     ui->callsignEdit->setText(receivedCallsign);
-    uiDynamic->gridEdit->setText(grid);
+
+    if ( !grid.isEmpty() )
+    {
+        uiDynamic->gridEdit->setText(grid);
+    }
+
     checkDupe();
     setDxccInfo(receivedCallsign);
     queryPota();
@@ -2951,7 +2957,9 @@ void NewContactWidget::prepareWSJTXQSO(const QString &receivedCallsign,
     // 1) prev Callsign empty grid
     // 2) new Callsign empty grid
     // 3) new Calllsign, new gris
-    if ( !grid.isEmpty() )
+    // WRITELOG workaround: Similar to JTDX, check application ID
+    // If ID contains "WRITELOG", always trigger callbook lookup
+    if ( !grid.isEmpty() || id.contains("WRITELOG") )
     {
         useFieldsFromPrevQSO(callsign, grid);
         finalizeCallsignEdit();

--- a/ui/NewContactWidget.h
+++ b/ui/NewContactWidget.h
@@ -236,7 +236,7 @@ public slots:
     void readGlobalSettings();
     void tuneDx(const DxSpot &spot);
     void fillCallsignGrid(const QString &callsign, const QString& grid);
-    void prepareWSJTXQSO(const QString &receivedCallsign, const QString &grid);
+    void prepareWSJTXQSO(const QString &receivedCallsign, const QString &grid, const QString &id);
     void resetContact();
     void saveContact();
 

--- a/ui/WsjtxWidget.cpp
+++ b/ui/WsjtxWidget.cpp
@@ -193,7 +193,7 @@ void WsjtxWidget::statusReceived(WsjtxStatus newStatus)
     if ( this->status.dx_call != newStatus.dx_call
          || this->status.dx_grid != newStatus.dx_grid )
     {
-        emit callsignSelected(newStatus.dx_call, newStatus.dx_grid);
+        emit callsignSelected(newStatus.dx_call, newStatus.dx_grid, newStatus.id);
     }
 
     if ( this->status.mode != newStatus.mode )

--- a/ui/WsjtxWidget.h
+++ b/ui/WsjtxWidget.h
@@ -35,7 +35,7 @@ private slots:
     void actionFilter();
 
 signals:
-    void callsignSelected(QString callsign, QString grid);
+    void callsignSelected(QString callsign, QString grid, QString id);
     void reply(WsjtxDecode);
     void CQSpot(WsjtxEntry);
     void filteredCQSpot(WsjtxEntry);


### PR DESCRIPTION
If the id of the WSJT-X packets contain "WRITELOG" then we should always do callbook lookups, even if there is no grid square present in the packet.