### PR TITLE
Update 'Not-Worked Only' filter logic and label

### DIFF
--- a/ui/AwardsDialog.ui
+++ b/ui/AwardsDialog.ui
@@ -218,14 +218,25 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="1">
-       <widget class="QCheckBox" name="notWorkedCheckBox">
-        <property name="text">
-         <string>Not-Worked/Not-Confirmed Only</string>
-        </property>
-       </widget>
+      <item row="4" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,5">
+        <item>
+         <widget class="QCheckBox" name="notWorkedCheckBox">
+          <property name="text">
+           <string>Not-Worked Only</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="notConfirmedCheckBox">
+          <property name="text">
+           <string>Not-Confirmed Only</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="notWorkedLabel">
         <property name="text">
          <string>Show</string>
@@ -474,6 +485,22 @@
     <hint type="sourcelabel">
      <x>562</x>
      <y>96</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>507</x>
+     <y>350</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>notConfirmedCheckBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>AwardsDialog</receiver>
+   <slot>refreshTable(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>628</x>
+     <y>325</y>
     </hint>
     <hint type="destinationlabel">
      <x>507</x>


### PR DESCRIPTION
#835 Modified the SQL HAVING clause to include cases where SUM(d.'band') equals 1, allowing filtering for both not-worked and not-confirmed entries. Updated the checkbox label in the UI to reflect this expanded filter.

<img width="1016" height="737" alt="image" src="https://github.com/user-attachments/assets/0f747d9e-cfce-498f-bf28-c2bff17e15ac" />
