### PR TITLE
Support customizing the tile server for online map

### DIFF
--- a/res/map/onlinemap.html
+++ b/res/map/onlinemap.html
@@ -67,7 +67,6 @@
   <div id="map"></div>
 
   <script>
-
     var grids_worked = [];    //field of Grids used for rendering Worked Grids
     var grids_confirmed = []; //field of Grids used for rendering Confirmed Grids
     var mylocations = [];     //field of My Locations
@@ -126,7 +125,6 @@
       popupAnchor: [1, -14]
     });
 
-
     var language = navigator.language || navigator.userLanguage;
     var mapUrl;
 
@@ -139,9 +137,16 @@
       mapUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     }
 
-    L.tileLayer(mapUrl, {
-      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a>'
-    }).addTo(map);
+    if (!window.tileConfig) {
+      window.tileConfig = {
+        url: mapUrl,
+        options: {
+          attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a>',
+        },
+      };
+    }
+
+    L.tileLayer(window.tileConfig.url, window.tileConfig.options).addTo(map);
 
     var maidenheadConfWorked = L.maidenheadConfWorked({color : 'rgba(255, 0, 0, 0.5)'}).addTo(map);
     var grayline = L.terminator({fillOpacity: 0.2})

--- a/ui/OnlineMapWidget.cpp
+++ b/ui/OnlineMapWidget.cpp
@@ -6,6 +6,9 @@
 #include <QVector3D>
 #include <QtMath>
 #include <QFile>
+#include <QJsonDocument>
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
 #include "OnlineMapWidget.h"
 #include "core/debug.h"
 #include "data/Gridsquare.h"
@@ -37,7 +40,7 @@ OnlineMapWidget::OnlineMapWidget(QWidget *parent):
     FCT_IDENTIFICATION;
 
     main_page->setWebChannel(&channel);
-
+    injectTileConfig();
     setPage(main_page);
     main_page->load(QUrl(QLatin1String("qrc:/res/map/onlinemap.html")));
     connect(this, &OnlineMapWidget::loadFinished, this, &OnlineMapWidget::finishLoading);
@@ -54,6 +57,36 @@ OnlineMapWidget::OnlineMapWidget(QWidget *parent):
     connect(&webChannelHandler, &MapWebChannelHandler::chatCallsignPressed, this, &OnlineMapWidget::chatCallsignTrigger);
     connect(&webChannelHandler, &MapWebChannelHandler::wsjtxCallsignPressed, this, &OnlineMapWidget::wsjtxCallsignTrigger);
     connect(&webChannelHandler, &MapWebChannelHandler::IBPPressed, this, &OnlineMapWidget::IBPCallsignTrigger);
+}
+
+void OnlineMapWidget::injectTileConfig()
+{
+    if (!main_page)
+        return;
+
+    QSettings settings;
+    QString optionsStr = settings.value("tileServer/config", "{}").toString();
+
+    QJsonDocument doc = QJsonDocument::fromJson(optionsStr.toUtf8());
+
+    if (doc.isObject()) {
+        QJsonObject obj = doc.object();
+        if (!obj.contains("url") || !obj["url"].isString() ||
+            !obj.contains("options") || !obj["options"].isObject()) {
+            optionsStr = "undefined";
+        }
+    }
+
+    QString jsCode = QString("window.tileConfig = %1;").arg(optionsStr);
+
+    QWebEngineScript script;
+    script.setName("InjectTileConfig");
+    script.setSourceCode(jsCode);
+    script.setInjectionPoint(QWebEngineScript::DocumentCreation);
+    script.setWorldId(QWebEngineScript::MainWorld);
+    script.setRunsOnSubFrames(false);
+
+    main_page->scripts().insert(script);
 }
 
 void OnlineMapWidget::setTarget(double lat, double lon)

--- a/ui/OnlineMapWidget.h
+++ b/ui/OnlineMapWidget.h
@@ -63,6 +63,7 @@ private:
     double lastSeenAzimuth, lastSeenElevation;
     bool isRotConnected;
 
+    void injectTileConfig(void);
     void runJavaScript(const QString &);
 };
 

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -293,6 +293,32 @@ SettingsDialog::SettingsDialog(MainWindow *parent) :
     ui->cwKeyModeSelect->addItem(tr("Ultimate"), CWKey::ULTIMATE);
     ui->cwKeyModeSelect->setCurrentIndex(ui->cwKeyModeSelect->findData(CWKey::IAMBIC_B));
 
+    tileServers.append({"OpenStreetMap (Default, System Language)", QJsonObject{}});
+    tileServers.append({"OpenStreetMap (English)", QJsonObject{
+        {"url", "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"},
+        {"options", QJsonObject{{"attribution", "&copy; OpenStreetMap"}}},
+    }});
+    tileServers.append({"OpenStreetMap (French)", QJsonObject{
+        {"url", "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png"},
+        {"options", QJsonObject{{"attribution", "&copy; OpenStreetMap"}}},
+    }});
+    tileServers.append({"OpenStreetMap (German)", QJsonObject{
+        {"url", "https://tile.openstreetmap.de/{z}/{x}/{y}.png"},
+        {"options", QJsonObject{{"attribution", "&copy; OpenStreetMap"}}},
+    }});
+
+    ui->tileServerComboBox->setEditable(true);
+    for (const auto &pair : tileServers) {
+        QString name = pair.first;
+        QJsonObject info = pair.second;
+        ui->tileServerComboBox->addItem(name);
+    }
+    ui->tileServerComboBox->addItem("Custom");
+
+    connect(ui->tileServerComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &SettingsDialog::onTileServerComboBoxChanged);
+    onTileServerComboBoxChanged(ui->tileServerComboBox->currentIndex());
+
     /* disable WSJTX Multicast by default */
     joinMulticastChanged(false);
 
@@ -300,6 +326,47 @@ SettingsDialog::SettingsDialog(MainWindow *parent) :
 
     readSettings();
 }
+
+void SettingsDialog::onTileServerComboBoxChanged(int index)
+{
+    bool isCustom = index == (ui->tileServerComboBox->count() - 1);
+    QString configStr = settings.value("tileServer/config", "{}").toString();
+
+    if (isCustom) {
+        ui->tileOptionsTextEdit->setReadOnly(false);
+        ui->tileMapUrlLineEdit->setReadOnly(false);
+
+        QJsonDocument info = QJsonDocument::fromJson(configStr.toUtf8());
+        if (info.object().isEmpty() || settings.value("tileServer/index", 0).toInt()) {
+            ui->tileMapUrlLineEdit->setText("");
+            ui->tileOptionsTextEdit->setPlainText("");
+            return;
+        };
+
+        QJsonObject obj = info.object();
+        ui->tileMapUrlLineEdit->setText(obj.contains("options") ? obj["url"].toString() : "");
+        ui->tileOptionsTextEdit->setPlainText(obj.contains("options")
+            ? QJsonDocument(obj["options"].toObject()).toJson(QJsonDocument::Compact)
+            : "");
+        return;
+    } else {
+        ui->tileOptionsTextEdit->setReadOnly(true);
+        ui->tileMapUrlLineEdit->setReadOnly(true);
+    }
+
+    QJsonObject info = tileServers[index].second;
+    if (info.isEmpty()) {
+        ui->tileMapUrlLineEdit->setText("");
+        ui->tileOptionsTextEdit->setPlainText("");
+        return;
+    };
+
+    ui->tileMapUrlLineEdit->setText(info.contains("options") ? info["url"].toString() : "");
+    ui->tileOptionsTextEdit->setPlainText(info.contains("options")
+                                              ? QJsonDocument(info["options"].toObject()).toJson(QJsonDocument::Compact)
+                                              : "");
+}
+
 
 void SettingsDialog::save() {
     FCT_IDENTIFICATION;
@@ -2401,6 +2468,21 @@ void SettingsDialog::readSettings()
     ui->dateFormatCustomRadioButton->setChecked(!dateSystemFormat);
     ui->dateFormatStringEdit->setText(locale.getSettingDateFormat());
 
+    /**************/
+    /* Online Map */
+    /**************/
+
+    int index = settings.value("tileServer/index", 0).toInt();
+    QString configStr = settings.value("tileServer/config", "{}").toString();
+
+    if (index >= ui->tileServerComboBox->count()) index = 0;
+    if (index == 0 && !QJsonDocument::fromJson(configStr.toUtf8()).object().isEmpty()) {
+        /* For convenience, `default' and `custom' use the same index, but options was stored only for `custom'. */
+        ui->tileServerComboBox->setCurrentIndex(ui->tileServerComboBox->count() - 1);
+    } else {
+        ui->tileServerComboBox->setCurrentIndex(index);
+    }
+
     /******************/
     /* END OF Reading */
     /******************/
@@ -2525,6 +2607,26 @@ void SettingsDialog::writeSettings()
     locale.setSettingUseSystemDateFormat(systemDateChecked);
     if ( !systemDateChecked )
         locale.setSettingDateFormat(ui->dateFormatStringEdit->text());
+
+    /**************/
+    /* Online Map */
+    /**************/
+    int index = ui->tileServerComboBox->currentIndex();
+    bool isCustom = index == (ui->tileServerComboBox->count() - 1);
+
+    if (isCustom) {
+        settings.setValue("tileServer/index", 0);
+        QJsonObject info = QJsonObject{
+            {"url", ui->tileMapUrlLineEdit->text()},
+            {"options", QJsonDocument::fromJson(ui->tileOptionsTextEdit->toPlainText().toUtf8()).object()}
+        };
+        settings.setValue("tileServer/config", QJsonDocument(info).toJson(QJsonDocument::Compact));
+        return;
+    }
+
+    settings.setValue("tileServer/index", index);
+    QJsonObject info = tileServers[index].second;
+    settings.setValue("tileServer/config", QJsonDocument(info).toJson(QJsonDocument::Compact));
 }
 
 /* this function is called when user modify rig progile

--- a/ui/SettingsDialog.h
+++ b/ui/SettingsDialog.h
@@ -133,6 +133,7 @@ private:
     void generateMembershipCheckboxes();
     void generateQRZAPICallsignTable();
     void saveQRZAPICallsignTable();
+    void onTileServerComboBoxChanged(int index);
 
     QSqlTableModel* modeTableModel;
     QSqlTableModel* bandTableModel;
@@ -151,6 +152,8 @@ private:
     QList<QCheckBox*> memberListCheckBoxes;
     Ui::SettingsDialog *ui;
     LogLocale locale;
+    QVector<QPair<QString, QJsonObject>> tileServers;
+    QSettings settings;
     bool sotaFallback;
     bool potaFallback;
     bool wwffFallback;

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -4564,6 +4564,106 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="onlineMapTab">
+      <attribute name="title">
+       <string>Online Map</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_20">
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="tileMapUrlLineEdit">
+           <property name="font">
+            <font>
+             <family>Monospace</family>
+            </font>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPlainTextEdit" name="tileOptionsTextEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <family>Monospace</family>
+            </font>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Options (JSON): </string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="tileServerComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Tile Server: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Map Url:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_25">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
In some countries with Internet censorship, the default OpenStreetMap tile server may not be accessible. This commit adds an option to choose the preferred tile server from a predefined list or customize them as needed.

By default, the online map retains the old behaviour which defaults to the user's system language and it also provides an option to choose the langugage for OSM.

<img width="804" height="411" alt="20251124_00h48m42s_grim" src="https://github.com/user-attachments/assets/8fd0d811-9880-4155-8709-33bafe0a0a32" />
<img width="1458" height="654" alt="20251124_00h47m46s_grim" src="https://github.com/user-attachments/assets/417d931c-cd69-410f-be22-84bcffd45a8b" />
