### PR TITLE
Add callsign highlighting for decoded WSJT-X messages

### DIFF
--- a/core/WsjtxUDPReceiver.h
+++ b/core/WsjtxUDPReceiver.h
@@ -6,6 +6,7 @@
 #include <QHostAddress>
 #include <QSqlRecord>
 #include <QNetworkDatagram>
+#include <QColor>
 
 #include "data/UpdatableSQLRecord.h"
 
@@ -180,6 +181,24 @@ private:
 
     void openPort();
     void forwardDatagram(const QNetworkDatagram &);
+
+    struct HighlightSpec {
+        QColor bg;
+        QColor fg;
+        bool lastOnly = false;
+    };
+
+    WsjtxStatus lastStatus;
+
+    HighlightSpec computeHighlightFor(const QString& dxCall,
+                                      const QString& band,
+                                      const QString& mode) const;
+
+    void sendHighlightCallsign(const QString& id,
+                               const QString& dxCall,
+                               const QColor& bg,
+                               const QColor& fg,
+                               bool highlightLast);
 };
 
 #endif // QLOG_CORE_WSJTXUDPRECEIVER_H


### PR DESCRIPTION
Introduces logic to parse decoded messages, extract callsigns, and send highlight instructions with computed background and foreground colors based on DXCC status and band. Adds HighlightSpec struct, computeHighlightFor, and sendHighlightCallsign methods to support this feature.

<img width="1152" height="1072" alt="image" src="https://github.com/user-attachments/assets/106d568a-820a-4fc3-b15c-4a92e3377b29" />
