### PR TITLE
Switch HamQTH API URL to HTTPS

### DIFF
--- a/service/hamqth/HamQTH.h
+++ b/service/hamqth/HamQTH.h
@@ -42,7 +42,7 @@ protected:
     void processReply(QNetworkReply* reply) override;
 
 private:
-    const QString API_URL = "http://www.hamqth.com/xml.php";
+    const QString API_URL = "https://www.hamqth.com/xml.php";
     QString sessionId;
     QString queuedCallsign;
     bool incorrectLogin;


### PR DESCRIPTION
Updated the API_URL in HamQTH.h to use HTTPS instead of HTTP for secure communication with the HamQTH service.  It was failing without https.  Reported by ZB3Z