### PR TITLE
ADIF file monitor and settings UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ compile_commands.json
 # QtCreator local machine specific files for imported projects
 *creator.user*
 .DS_Store
+/build

--- a/QLog.pro
+++ b/QLog.pro
@@ -55,6 +55,7 @@ CONFIG += c++11 force_debug_info
 CONFIG *= link_pkgconfig
 
 SOURCES += \
+        core/ADIFFileMonitor.cpp \
         core/AlertEvaluator.cpp \
         core/AppGuard.cpp \
         core/CallbookManager.cpp \
@@ -202,6 +203,7 @@ SOURCES += \
         ui/component/SwitchButton.cpp
 
 HEADERS += \
+        core/ADIFFileMonitor.h \
         core/AlertEvaluator.h \
         core/AppGuard.h \
         core/CallbookManager.h \

--- a/core/ADIFFileMonitor.cpp
+++ b/core/ADIFFileMonitor.cpp
@@ -1,0 +1,155 @@
+#include <QFile>
+#include <QTextStream>
+#include <QFileInfo>
+#include <QMessageBox>
+#include <QSpacerItem>
+#include <QGridLayout>
+
+#include "ADIFFileMonitor.h"
+#include "core/LogParam.h"
+#include "core/debug.h"
+#include "data/StationProfile.h"
+#include "logformat/LogFormat.h"
+
+MODULE_IDENTIFICATION("qlog.core.adiffilemonitor");
+
+ADIFFileMonitor::ADIFFileMonitor(QObject *parent)
+    : QObject(parent)
+{
+    FCT_IDENTIFICATION;
+}
+
+ADIFFileMonitor::~ADIFFileMonitor()
+{
+    FCT_IDENTIFICATION;
+}
+
+QList<ADIFFileMonitor::SlotConfig> ADIFFileMonitor::getEnabledSlots(ImportFrequency freq) const
+{
+    FCT_IDENTIFICATION;
+
+    QList<SlotConfig> result;
+
+    for ( int i = 0; i < MAX_SLOTS; ++i )
+    {
+        SlotConfig cfg;
+        cfg.enabled   = LogParam::getADIFMonitorEnabled(i);
+        cfg.path      = LogParam::getADIFMonitorPath(i);
+        cfg.frequency = static_cast<ImportFrequency>(LogParam::getADIFMonitorFrequency(i));
+        cfg.profile   = LogParam::getADIFMonitorProfile(i);
+
+        if ( cfg.enabled && cfg.frequency == freq && !cfg.path.isEmpty() )
+            result.append(cfg);
+    }
+
+    return result;
+}
+
+LogFormat::duplicateQSOBehaviour ADIFFileMonitor::skipAllDuplicates(QSqlRecord *, QSqlRecord *)
+{
+    return LogFormat::SKIP_ALL;
+}
+
+void ADIFFileMonitor::runImportForSlot(const SlotConfig &slot)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(runtime) << "ADIF Monitor importing:" << slot.path;
+
+    QFile file(slot.path);
+
+    if ( !file.exists() )
+    {
+        qCWarning(runtime) << "ADIF Monitor: file not found:" << slot.path;
+        return;
+    }
+
+    if ( !file.open(QFile::ReadOnly | QFile::Text) )
+    {
+        qCWarning(runtime) << "ADIF Monitor: cannot open file:" << slot.path;
+        return;
+    }
+
+    QTextStream in(&file);
+
+    LogFormat *format = LogFormat::open("adi", in);
+
+    if ( !format )
+    {
+        qCWarning(runtime) << "ADIF Monitor: failed to open as ADIF:" << slot.path;
+        return;
+    }
+
+    format->setDuplicateQSOCallback(skipAllDuplicates);
+
+    StationProfile stationProfile;
+
+    if ( !slot.profile.isEmpty() )
+        stationProfile = StationProfilesManager::instance()->getProfile(slot.profile);
+
+    if ( stationProfile == StationProfile() )
+        stationProfile = StationProfilesManager::instance()->getCurProfile1();
+
+    const StationProfile *profile = ( stationProfile != StationProfile() ) ? &stationProfile : nullptr;
+
+    unsigned long warnings = 0;
+    unsigned long errors   = 0;
+    QString logStream;
+    QTextStream logOut(&logStream);
+
+    int count = format->runImport(logOut, profile, &warnings, &errors);
+
+    if (count > 0)
+    {
+        QString s;
+        QString report = QObject::tr("<b>Import File</b>: ") +  slot.path + "<br/>" +
+                         QObject::tr("<b>Imported</b>: %n contact(s)", "", count) + "<br/>" +
+                         QObject::tr("<b>Warning(s)</b>: %n", "", warnings) + "<br/>" +
+                         QObject::tr("<b>Error(s)</b>: %n", "", errors);
+
+        QMessageBox msgBox;
+
+        msgBox.setWindowTitle(tr("Import Result"));
+        msgBox.setText(report);
+        msgBox.setDetailedText(s);
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.setDefaultButton(QMessageBox::Ok);
+
+        QSpacerItem* horizontalSpacer = new QSpacerItem(500, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+        QGridLayout* layout = qobject_cast<QGridLayout*>(msgBox.layout());
+        if ( !layout )
+        {
+            qWarning() << "Layout is null";
+            delete horizontalSpacer;
+            return;
+        }
+        layout->addItem(horizontalSpacer, layout->rowCount(), 0, 1, layout->columnCount());
+
+        msgBox.exec();
+
+    }
+    delete format;
+
+    qCDebug(runtime) << "ADIF Monitor import finished. Warnings:" << warnings << "Errors:" << errors;
+}
+
+void ADIFFileMonitor::runStartupImports()
+{
+    FCT_IDENTIFICATION;
+
+    const QList<SlotConfig> fileSlots = getEnabledSlots(STARTUP);
+
+    for ( const SlotConfig &cfg : fileSlots )
+        runImportForSlot(cfg);
+}
+
+void ADIFFileMonitor::runShutdownImports()
+{
+    FCT_IDENTIFICATION;
+
+    const QList<SlotConfig> fileSlots = getEnabledSlots(SHUTDOWN);
+
+    for ( const SlotConfig &cfg : fileSlots )
+        runImportForSlot(cfg);
+}

--- a/core/ADIFFileMonitor.h
+++ b/core/ADIFFileMonitor.h
@@ -1,0 +1,40 @@
+#ifndef QLOG_CORE_ADIFFILEMONITOR_H
+#define QLOG_CORE_ADIFFILEMONITOR_H
+
+#include <QObject>
+#include <QSqlRecord>
+#include "logformat/LogFormat.h"
+
+class ADIFFileMonitor : public QObject
+{
+    Q_OBJECT
+
+public:
+    static const int MAX_SLOTS = 4;
+
+    enum ImportFrequency {
+        DISABLED = 0,
+        STARTUP  = 1,
+        SHUTDOWN = 2
+    };
+
+    explicit ADIFFileMonitor(QObject *parent = nullptr);
+    ~ADIFFileMonitor();
+
+    void runStartupImports();
+    void runShutdownImports();
+
+private:
+    struct SlotConfig {
+        bool enabled = false;
+        QString path;
+        ImportFrequency frequency = DISABLED;
+        QString profile;
+    };
+
+    QList<SlotConfig> getEnabledSlots(ImportFrequency freq) const;
+    void runImportForSlot(const SlotConfig &slot);
+    static LogFormat::duplicateQSOBehaviour skipAllDuplicates(QSqlRecord *, QSqlRecord *);
+};
+
+#endif // QLOG_CORE_ADIFFILEMONITOR_H

--- a/core/LogParam.cpp
+++ b/core/LogParam.cpp
@@ -1247,6 +1247,46 @@ void LogParam::removeMainWindowBandmapWidgets()
     removeParamGroup("mainwindow/bandmapwidgets");
 }
 
+bool LogParam::getADIFMonitorEnabled(int slot)
+{
+    return getParam(QString("adifmonitor/slot%1/enabled").arg(slot), false).toBool();
+}
+
+void LogParam::setADIFMonitorEnabled(int slot, bool enabled)
+{
+    setParam(QString("adifmonitor/slot%1/enabled").arg(slot), enabled);
+}
+
+QString LogParam::getADIFMonitorPath(int slot)
+{
+    return getParam(QString("adifmonitor/slot%1/path").arg(slot)).toString();
+}
+
+void LogParam::setADIFMonitorPath(int slot, const QString &path)
+{
+    setParam(QString("adifmonitor/slot%1/path").arg(slot), path);
+}
+
+int LogParam::getADIFMonitorFrequency(int slot)
+{
+    return getParam(QString("adifmonitor/slot%1/frequency").arg(slot), 0).toInt();
+}
+
+void LogParam::setADIFMonitorFrequency(int slot, int frequency)
+{
+    setParam(QString("adifmonitor/slot%1/frequency").arg(slot), frequency);
+}
+
+QString LogParam::getADIFMonitorProfile(int slot)
+{
+    return getParam(QString("adifmonitor/slot%1/profile").arg(slot)).toString();
+}
+
+void LogParam::setADIFMonitorProfile(int slot, const QString &profile)
+{
+    setParam(QString("adifmonitor/slot%1/profile").arg(slot), profile);
+}
+
 bool LogParam::setParam(const QString &name, const QVariant &value)
 {
     FCT_IDENTIFICATION;

--- a/core/LogParam.h
+++ b/core/LogParam.h
@@ -357,6 +357,18 @@ public:
     static void setSourcePlatform(const QString &platform);
     static void removeSourcePlatform();
 
+    /**********************
+     * ADIF File Monitor
+     **********************/
+    static bool getADIFMonitorEnabled(int slot);
+    static void setADIFMonitorEnabled(int slot, bool enabled);
+    static QString getADIFMonitorPath(int slot);
+    static void setADIFMonitorPath(int slot, const QString &path);
+    static int getADIFMonitorFrequency(int slot);
+    static void setADIFMonitorFrequency(int slot, int frequency);
+    static QString getADIFMonitorProfile(int slot);
+    static void setADIFMonitorProfile(int slot, const QString &profile);
+
     /**************
      * Main Window
      *************/

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -461,6 +461,11 @@ MainWindow::MainWindow(QWidget* parent) :
     //restoreConnectionStates();
 
     setupActivitiesMenu();
+
+    /************************/
+    /* ADIF File Monitor    */
+    /************************/
+    adifMonitor.runStartupImports();
 }
 
 void MainWindow::closeEvent(QCloseEvent* event)
@@ -511,6 +516,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
         qCDebug(runtime) << "Removing orphan configuration" << orphanConfig;
         LogParam::removeBandmapWidgetGroup(orphanConfig);
     }
+
+    /****************************/
+    /* ADIF File Monitor        */
+    /****************************/
+    adifMonitor.runShutdownImports();
 
     // Save unsaved widget states
     const auto allWidgets = findChildren<QWidget *>();

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -6,6 +6,7 @@
 #include <QActionGroup>
 #include "ui/StatisticsWidget.h"
 #include "core/NetworkNotification.h"
+#include "core/ADIFFileMonitor.h"
 #include "core/AlertEvaluator.h"
 #include "core/PropConditions.h"
 #include "service/clublog/ClubLog.h"
@@ -109,6 +110,7 @@ private:
     QPushButton *themeButton;
     StatisticsWidget* stats;
     NetworkNotification networknotification;
+    ADIFFileMonitor adifMonitor;
     AlertEvaluator alertEvaluator;
     PropConditions *conditions;
     bool isFusionStyle;

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -40,6 +40,7 @@
 #include "service/cloudlog/Cloudlog.h"
 #include "ui/RigctldAdvancedDialog.h"
 #include "cwkey/drivers/CWWinKey.h"
+#include "core/ADIFFileMonitor.h"
 
 #define STACKED_WIDGET_SERIAL_SETTING  0
 #define STACKED_WIDGET_NETWORK_SETTING 1
@@ -328,6 +329,29 @@ SettingsDialog::SettingsDialog(MainWindow *parent) :
     joinMulticastChanged(false);
 
     generateMembershipCheckboxes();
+
+    /**********************/
+    /* ADIF File Monitor  */
+    /**********************/
+    {
+        const QStringList profiles = stationProfManager->profileNameList();
+        const QList<QComboBox*> profileCombos = {
+            ui->adifMonitorProfile0,
+            ui->adifMonitorProfile1,
+            ui->adifMonitorProfile2,
+            ui->adifMonitorProfile3
+        };
+        for ( QComboBox *combo : profileCombos )
+        {
+            combo->addItem(tr("(none)"), QString());
+            for ( const QString &p : profiles )
+                combo->addItem(p, p);
+        }
+        connect(ui->adifMonitorBrowse0, &QToolButton::clicked, this, &SettingsDialog::adifMonitorBrowse0);
+        connect(ui->adifMonitorBrowse1, &QToolButton::clicked, this, &SettingsDialog::adifMonitorBrowse1);
+        connect(ui->adifMonitorBrowse2, &QToolButton::clicked, this, &SettingsDialog::adifMonitorBrowse2);
+        connect(ui->adifMonitorBrowse3, &QToolButton::clicked, this, &SettingsDialog::adifMonitorBrowse3);
+    }
 
     readSettings();
 }
@@ -2622,6 +2646,26 @@ void SettingsDialog::readSettings()
     ui->notifSpotAlertEdit->setText(NetworkNotification::getNotifSpotAlertAddrs());
     ui->notifRigEdit->setText(NetworkNotification::getNotifRigStateAddrs());
 
+    /**********************/
+    /* ADIF File Monitor  */
+    /**********************/
+    {
+        const QList<QCheckBox*>  enabledChecks = { ui->adifMonitorEnabled0, ui->adifMonitorEnabled1, ui->adifMonitorEnabled2, ui->adifMonitorEnabled3 };
+        const QList<QLineEdit*>  pathEdits     = { ui->adifMonitorPath0,    ui->adifMonitorPath1,    ui->adifMonitorPath2,    ui->adifMonitorPath3    };
+        const QList<QComboBox*>  freqCombos    = { ui->adifMonitorFrequency0, ui->adifMonitorFrequency1, ui->adifMonitorFrequency2, ui->adifMonitorFrequency3 };
+        const QList<QComboBox*>  profCombos    = { ui->adifMonitorProfile0, ui->adifMonitorProfile1, ui->adifMonitorProfile2, ui->adifMonitorProfile3 };
+
+        for ( int i = 0; i < ADIFFileMonitor::MAX_SLOTS; ++i )
+        {
+            enabledChecks[i]->setChecked(LogParam::getADIFMonitorEnabled(i));
+            pathEdits[i]->setText(LogParam::getADIFMonitorPath(i));
+            freqCombos[i]->setCurrentIndex(LogParam::getADIFMonitorFrequency(i));
+            const QString savedProfile = LogParam::getADIFMonitorProfile(i);
+            const int profileIdx = profCombos[i]->findData(savedProfile);
+            profCombos[i]->setCurrentIndex(profileIdx >= 0 ? profileIdx : 0);
+        }
+    }
+
     /*******/
     /* GUI */
     /*******/
@@ -2752,6 +2796,24 @@ void SettingsDialog::writeSettings()
     NetworkNotification::saveNotifWSJTXCQSpotAddrs(ui->notifWSJTXCQSpotsEdit->text());
     NetworkNotification::saveNotifSpotAlertAddrs(ui->notifSpotAlertEdit->text());
     NetworkNotification::saveNotifRigStateAddrs(ui->notifRigEdit->text());
+
+    /**********************/
+    /* ADIF File Monitor  */
+    /**********************/
+    {
+        const QList<QCheckBox*>  enabledChecks = { ui->adifMonitorEnabled0, ui->adifMonitorEnabled1, ui->adifMonitorEnabled2, ui->adifMonitorEnabled3 };
+        const QList<QLineEdit*>  pathEdits     = { ui->adifMonitorPath0,    ui->adifMonitorPath1,    ui->adifMonitorPath2,    ui->adifMonitorPath3    };
+        const QList<QComboBox*>  freqCombos    = { ui->adifMonitorFrequency0, ui->adifMonitorFrequency1, ui->adifMonitorFrequency2, ui->adifMonitorFrequency3 };
+        const QList<QComboBox*>  profCombos    = { ui->adifMonitorProfile0, ui->adifMonitorProfile1, ui->adifMonitorProfile2, ui->adifMonitorProfile3 };
+
+        for ( int i = 0; i < ADIFFileMonitor::MAX_SLOTS; ++i )
+        {
+            LogParam::setADIFMonitorEnabled(i, enabledChecks[i]->isChecked());
+            LogParam::setADIFMonitorPath(i, pathEdits[i]->text());
+            LogParam::setADIFMonitorFrequency(i, freqCombos[i]->currentIndex());
+            LogParam::setADIFMonitorProfile(i, profCombos[i]->currentData().toString());
+        }
+    }
 
     /*******/
     /* GUI */
@@ -3063,6 +3125,46 @@ void SettingsDialog::updateCountyCompleter(int dxcc)
         return;
     countyCompleter = Data::createCountyCompleter(dxcc, this);
     ui->stationCountyEdit->setCompleter(countyCompleter);
+}
+
+void SettingsDialog::adifMonitorBrowse0()
+{
+    FCT_IDENTIFICATION;
+    QString filename = QFileDialog::getOpenFileName(this, tr("Select ADIF File"),
+                                                    QDir::homePath(),
+                                                    tr("ADIF Files (*.adi *.ADI)"));
+    if ( !filename.isEmpty() )
+        ui->adifMonitorPath0->setText(filename);
+}
+
+void SettingsDialog::adifMonitorBrowse1()
+{
+    FCT_IDENTIFICATION;
+    QString filename = QFileDialog::getOpenFileName(this, tr("Select ADIF File"),
+                                                    QDir::homePath(),
+                                                    tr("ADIF Files (*.adi *.ADI)"));
+    if ( !filename.isEmpty() )
+        ui->adifMonitorPath1->setText(filename);
+}
+
+void SettingsDialog::adifMonitorBrowse2()
+{
+    FCT_IDENTIFICATION;
+    QString filename = QFileDialog::getOpenFileName(this, tr("Select ADIF File"),
+                                                    QDir::homePath(),
+                                                    tr("ADIF Files (*.adi *.ADI)"));
+    if ( !filename.isEmpty() )
+        ui->adifMonitorPath2->setText(filename);
+}
+
+void SettingsDialog::adifMonitorBrowse3()
+{
+    FCT_IDENTIFICATION;
+    QString filename = QFileDialog::getOpenFileName(this, tr("Select ADIF File"),
+                                                    QDir::homePath(),
+                                                    tr("ADIF Files (*.adi *.ADI)"));
+    if ( !filename.isEmpty() )
+        ui->adifMonitorPath3->setText(filename);
 }
 
 SettingsDialog::~SettingsDialog() {

--- a/ui/SettingsDialog.h
+++ b/ui/SettingsDialog.h
@@ -118,6 +118,10 @@ public slots:
     void assignedKeyChanged(int);
     void testWebLookupURL();
     void joinMulticastChanged(int);
+    void adifMonitorBrowse0();
+    void adifMonitorBrowse1();
+    void adifMonitorBrowse2();
+    void adifMonitorBrowse3();
     void adjustWSJTXMulticastAddrTextColor();
     void hrdlogSettingChanged();
     void clublogSettingChanged();

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -4668,6 +4668,279 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="adifMonitorGroupBox">
+         <property name="title">
+          <string>ADIF File Monitor</string>
+         </property>
+         <layout class="QGridLayout" name="adifMonitorGridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="adifMonitorHeaderEnabledLabel">
+            <property name="text">
+             <string>Enabled</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="adifMonitorHeaderFileLabel">
+            <property name="text">
+             <string>File</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="adifMonitorHeaderWhenLabel">
+            <property name="text">
+             <string>When</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLabel" name="adifMonitorHeaderProfileLabel">
+            <property name="text">
+             <string>Station Profile</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="adifMonitorEnabled0">
+            <property name="toolTip">
+             <string>Enable monitoring of this ADIF file</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="adifMonitorPath0">
+            <property name="toolTip">
+             <string>Path to the ADIF file to monitor and import</string>
+            </property>
+            <property name="placeholderText">
+             <string>Select ADIF file...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QToolButton" name="adifMonitorBrowse0">
+            <property name="toolTip">
+             <string>Browse for ADIF file</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QComboBox" name="adifMonitorFrequency0">
+            <property name="toolTip">
+             <string>When to import this file</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Startup</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shutdown</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QComboBox" name="adifMonitorProfile0">
+            <property name="toolTip">
+             <string>Default station profile to apply when importing (used when the ADIF record does not contain station data)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="adifMonitorEnabled1">
+            <property name="toolTip">
+             <string>Enable monitoring of this ADIF file</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="adifMonitorPath1">
+            <property name="toolTip">
+             <string>Path to the ADIF file to monitor and import</string>
+            </property>
+            <property name="placeholderText">
+             <string>Select ADIF file...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QToolButton" name="adifMonitorBrowse1">
+            <property name="toolTip">
+             <string>Browse for ADIF file</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QComboBox" name="adifMonitorFrequency1">
+            <property name="toolTip">
+             <string>When to import this file</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Startup</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shutdown</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QComboBox" name="adifMonitorProfile1">
+            <property name="toolTip">
+             <string>Default station profile to apply when importing (used when the ADIF record does not contain station data)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="adifMonitorEnabled2">
+            <property name="toolTip">
+             <string>Enable monitoring of this ADIF file</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="adifMonitorPath2">
+            <property name="toolTip">
+             <string>Path to the ADIF file to monitor and import</string>
+            </property>
+            <property name="placeholderText">
+             <string>Select ADIF file...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QToolButton" name="adifMonitorBrowse2">
+            <property name="toolTip">
+             <string>Browse for ADIF file</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QComboBox" name="adifMonitorFrequency2">
+            <property name="toolTip">
+             <string>When to import this file</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Startup</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shutdown</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QComboBox" name="adifMonitorProfile2">
+            <property name="toolTip">
+             <string>Default station profile to apply when importing (used when the ADIF record does not contain station data)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="adifMonitorEnabled3">
+            <property name="toolTip">
+             <string>Enable monitoring of this ADIF file</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="adifMonitorPath3">
+            <property name="toolTip">
+             <string>Path to the ADIF file to monitor and import</string>
+            </property>
+            <property name="placeholderText">
+             <string>Select ADIF file...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QToolButton" name="adifMonitorBrowse3">
+            <property name="toolTip">
+             <string>Browse for ADIF file</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QComboBox" name="adifMonitorFrequency3">
+            <property name="toolTip">
+             <string>When to import this file</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Disabled</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Startup</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shutdown</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="4">
+           <widget class="QComboBox" name="adifMonitorProfile3">
+            <property name="toolTip">
+             <string>Default station profile to apply when importing (used when the ADIF record does not contain station data)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Users can configure up to 4 ADIF file slots, each independently set to import on application startup or shutdown. This is aimed at workflows like WSJT-X where a log file is continuously written externally and needs to be synced into QLog. #941 

<img width="887" height="858" alt="image" src="https://github.com/user-attachments/assets/2565434d-96ca-46e4-a48b-439586125eee" />

If any contacts are imported a summary like this will appear for each file:
<img width="550" height="187" alt="image" src="https://github.com/user-attachments/assets/069b85d7-979c-4dd4-8b08-60122008ce9f" />
