### PR TITLE
Fix ADIF import losing diacritics (UTF-8 instead of Latin-1)

### DIFF
--- a/logformat/AdiFormat.cpp
+++ b/logformat/AdiFormat.cpp
@@ -677,9 +677,9 @@ AdiFormat::AdiFormat(QTextStream &stream) :
     FCT_IDENTIFICATION;
 
 #if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-    stream.setEncoding(QStringConverter::Latin1);
+    stream.setEncoding(QStringConverter::Utf8);
 #else
-    stream.setCodec("ISO 8859-1");
+    stream.setCodec("UTF-8");
 #endif
 }
 


### PR DESCRIPTION
## Summary
- ADIF import used Latin-1 / ISO 8859-1 encoding, which corrupted non-ASCII characters (diacritics) in fields like QTH, NAME, COMMENT
- Changed `QTextStream` encoding to UTF-8 for both Qt6 (`QStringConverter::Utf8`) and Qt5 (`"UTF-8"`) code paths
- Affects any ADIF file containing characters outside the Latin-1 range (common in Central/Eastern European, French, German QTH names)

## Problem
When importing an ADIF file with UTF-8 encoded diacritics (e.g. QTH names like "Trójgarb", "Devínska Kobyla", "Montagne de Mélan", "Kühberg"), the characters were decoded as Latin-1, producing garbled text in the log.

Most modern ADIF loggers export UTF-8 by default (Ham2K Portable Logger, SOTA database exports, etc.), so this is a common real-world issue.

## Fix
Two-line change in `logformat/AdiFormat.cpp` — switch the `QTextStream` encoding from Latin-1 to UTF-8 in the stream setup (both Qt5 and Qt6 branches).

## Test plan
- [ ] Import an ADIF file containing diacritics (e.g. Slovak, Polish, French, German place names)
- [ ] Verify QTH, NAME, COMMENT fields display correctly in the logbook
- [ ] Export the imported QSOs and verify diacritics survive the round-trip
- [ ] Import a plain ASCII ADIF file to confirm no regression
