### PR TITLE
shutdown: synchronize station-device teardown

### DIFF
--- a/core/main.cpp
+++ b/core/main.cpp
@@ -32,6 +32,9 @@ MODULE_IDENTIFICATION("qlog.core.main");
 static QMutex debug_mutex;
 static QFile debugLogFile;
 static QTextStream debugLogStream;
+static QThread *rigThreadHandle = nullptr;
+static QThread *rotThreadHandle = nullptr;
+static QThread *cwKeyerThreadHandle = nullptr;
 
 QTemporaryDir tempDir
 #ifdef QLOG_FLATPAK
@@ -156,32 +159,50 @@ static void createDataDirectory() {
 static void startRigThread() {
     FCT_IDENTIFICATION;
 
-    QThread* rigThread = new QThread;
+    rigThreadHandle = new QThread;
     Rig* rig = Rig::instance();
-    rig->moveToThread(rigThread);
-    QObject::connect(rigThread, SIGNAL(started()), rig, SLOT(start()));
-    rigThread->start();
+    rig->moveToThread(rigThreadHandle);
+    QObject::connect(rigThreadHandle, SIGNAL(started()), rig, SLOT(start()));
+    rigThreadHandle->start();
 }
 
 static void startRotThread() {
     FCT_IDENTIFICATION;
 
-    QThread* rotThread = new QThread;
+    rotThreadHandle = new QThread;
     Rotator* rot = Rotator::instance();
-    rot->moveToThread(rotThread);
-    QObject::connect(rotThread, SIGNAL(started()), rot, SLOT(start()));
-    rotThread->start();
+    rot->moveToThread(rotThreadHandle);
+    QObject::connect(rotThreadHandle, SIGNAL(started()), rot, SLOT(start()));
+    rotThreadHandle->start();
 }
 
 static void startCWKeyerThread()
 {
     FCT_IDENTIFICATION;
 
-    QThread* cwKeyerThread = new QThread;
+    cwKeyerThreadHandle = new QThread;
     CWKeyer* cwKeyer = CWKeyer::instance();
-    cwKeyer->moveToThread(cwKeyerThread);
-    QObject::connect(cwKeyerThread, SIGNAL(started()), cwKeyer, SLOT(start()));
-    cwKeyerThread->start();
+    cwKeyer->moveToThread(cwKeyerThreadHandle);
+    QObject::connect(cwKeyerThreadHandle, SIGNAL(started()), cwKeyer, SLOT(start()));
+    cwKeyerThreadHandle->start();
+}
+
+static void stopWorkerThread(QThread *&threadHandle, const QString &threadName)
+{
+    FCT_IDENTIFICATION;
+
+    if ( !threadHandle )
+        return;
+
+    threadHandle->quit();
+    if ( !threadHandle->wait(5000) )
+    {
+        qCWarning(runtime) << threadName << "thread did not stop within timeout";
+        return;
+    }
+
+    delete threadHandle;
+    threadHandle = nullptr;
 }
 
 void closeDebugLogFile()
@@ -481,19 +502,29 @@ int main(int argc, char* argv[])
     startRotThread();
     startCWKeyerThread();
 
-    MainWindow w;
-    QIcon icon(":/res/qlog.png");
+    int rc = 0;
 
-    w.setWindowIcon(icon);
+    {
+        MainWindow w;
+        QIcon icon(":/res/qlog.png");
 
-    splash.finish(&w);
-    w.show();
+        w.setWindowIcon(icon);
 
-    w.setLayoutGeometry();
+        splash.finish(&w);
+        w.show();
 
-    // check version only for Windows and MacOS. Linux has own distribution points
+        w.setLayoutGeometry();
+
+        // check version only for Windows and MacOS. Linux has own distribution points
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-    w.checkNewVersion();
+        w.checkNewVersion();
 #endif
-    return app.exec();
+        rc = app.exec();
+    }
+
+    stopWorkerThread(cwKeyerThreadHandle, "CWKeyer");
+    stopWorkerThread(rotThreadHandle, "Rotator");
+    stopWorkerThread(rigThreadHandle, "Rig");
+
+    return rc;
 }

--- a/cwkey/CWKeyer.cpp
+++ b/cwkey/CWKeyer.cpp
@@ -7,6 +7,7 @@
 #include "cwkey/drivers/CWFldigiKey.h"
 #include "core/debug.h"
 #include "data/CWKeyProfile.h"
+#include <QThread>
 
 MODULE_IDENTIFICATION("qlog.cwkey.cwkeyer");
 
@@ -25,6 +26,31 @@ void CWKeyer::stopTimer()
 {
     FCT_IDENTIFICATION;
     bool check = QMetaObject::invokeMethod(CWKeyer::instance(), &CWKeyer::stopTimerImplt, Qt::QueuedConnection);
+    Q_ASSERT( check );
+}
+
+void CWKeyer::shutdown()
+{
+    FCT_IDENTIFICATION;
+
+    if ( QThread::currentThread() == thread() )
+    {
+        closeImpl();
+        stopTimerImplt();
+        return;
+    }
+
+    if ( !thread() || !thread()->isRunning() )
+    {
+        qCWarning(runtime) << "Cannot synchronously shut down CWKeyer because owner thread is not running";
+        return;
+    }
+
+    bool check = QMetaObject::invokeMethod(this, [this]()
+    {
+        closeImpl();
+        stopTimerImplt();
+    }, Qt::BlockingQueuedConnection);
     Q_ASSERT( check );
 }
 
@@ -276,7 +302,7 @@ void CWKeyer::__closeCWKey()
     if ( cwKey )
     {
         cwKey->close();
-        cwKey->deleteLater();
+        delete cwKey;
         cwKey = nullptr;
     }
 
@@ -419,8 +445,15 @@ CWKeyer::~CWKeyer()
 {
     FCT_IDENTIFICATION;
 
-    if ( cwKey )
+    if ( !cwKey && !timer )
+        return;
+
+    if ( QThread::currentThread() != thread() )
     {
-        cwKey->deleteLater();
+        qCWarning(runtime) << "Skipping CWKeyer shutdown from non-owner thread";
+        return;
     }
+
+    __closeCWKey();
+    stopTimerImplt();
 }

--- a/cwkey/CWKeyer.cpp
+++ b/cwkey/CWKeyer.cpp
@@ -7,6 +7,9 @@
 #include "cwkey/drivers/CWFldigiKey.h"
 #include "core/debug.h"
 #include "data/CWKeyProfile.h"
+#include <QAtomicInt>
+#include <QSemaphore>
+#include <QSharedPointer>
 #include <QThread>
 
 MODULE_IDENTIFICATION("qlog.cwkey.cwkeyer");
@@ -35,23 +38,45 @@ void CWKeyer::shutdown()
 
     if ( QThread::currentThread() == thread() )
     {
-        closeImpl();
-        stopTimerImplt();
+        shutdownImpl();
         return;
     }
 
     if ( !thread() || !thread()->isRunning() )
     {
-        qCWarning(runtime) << "Cannot synchronously shut down CWKeyer because owner thread is not running";
+        qCWarning(runtime) << "Cannot shut down CWKeyer because owner thread is not running";
         return;
     }
 
-    bool check = QMetaObject::invokeMethod(this, [this]()
+    QSharedPointer<QSemaphore> shutdownDone = QSharedPointer<QSemaphore>::create();
+    QSharedPointer<QAtomicInt> shutdownCanceled = QSharedPointer<QAtomicInt>::create(0);
+    bool check = QMetaObject::invokeMethod(this, [this, shutdownDone, shutdownCanceled]()
     {
-        closeImpl();
-        stopTimerImplt();
-    }, Qt::BlockingQueuedConnection);
-    Q_ASSERT( check );
+        if ( !shutdownCanceled->loadAcquire() )
+        {
+            shutdownImpl();
+        }
+        shutdownDone->release();
+    }, Qt::QueuedConnection);
+    if ( !check )
+    {
+        qCWarning(runtime) << "Failed to queue CWKeyer shutdown";
+        return;
+    }
+
+    if ( !shutdownDone->tryAcquire(1, SHUTDOWN_TIMEOUT_MS) )
+    {
+        shutdownCanceled->storeRelease(1);
+        qCWarning(runtime) << "CWKeyer shutdown timed out";
+    }
+}
+
+void CWKeyer::shutdownImpl()
+{
+    FCT_IDENTIFICATION;
+
+    closeImpl();
+    stopTimerImplt();
 }
 
 void CWKeyer::update()
@@ -100,9 +125,8 @@ void CWKeyer::openImpl()
 {
     FCT_IDENTIFICATION;
 
-    cwKeyLock.lock();
+    QMutexLocker locker(&cwKeyLock);
     __openCWKey();
-    cwKeyLock.unlock();
 }
 
 void CWKeyer::__openCWKey()
@@ -287,10 +311,9 @@ void CWKeyer::closeImpl()
     FCT_IDENTIFICATION;
 
     qCDebug(runtime) << "Waiting for cwkey mutex";
-    cwKeyLock.lock();
+    QMutexLocker locker(&cwKeyLock);
     qCDebug(runtime) << "Using Key";
     __closeCWKey();
-    cwKeyLock.unlock();
 }
 
 void CWKeyer::__closeCWKey()

--- a/cwkey/CWKeyer.h
+++ b/cwkey/CWKeyer.h
@@ -49,6 +49,7 @@ private slots:
     void sendTextImpl(const QString&);
     void immediatelyStopImpl();
     void stopTimerImplt();
+    void shutdownImpl();
     void keyErrorHandler(const QString&, const QString&);
     void cwKeyWPMChangedHandler(qint32);
     void cwKeyEchoTextHandler(const QString&);
@@ -68,6 +69,7 @@ private:
     CWKeyProfile connectedCWKeyProfile;
     QMutex cwKeyLock;
     QTimer* timer;
+    static const int SHUTDOWN_TIMEOUT_MS = 5000;
 };
 
 #endif // QLOG_CWKEY_CWKEYER_H

--- a/cwkey/CWKeyer.h
+++ b/cwkey/CWKeyer.h
@@ -32,6 +32,7 @@ public slots:
     void update();
     void open();
     void close();
+    void shutdown();
     bool canStopSending();
     bool canEchoChar();
     bool rigMustConnected();

--- a/rig/Rig.cpp
+++ b/rig/Rig.cpp
@@ -1,6 +1,9 @@
 #include "Rig.h"
 #include "RigctldManager.h"
 #include "core/debug.h"
+
+#include <QThread>
+
 #include "rig/drivers/HamlibRigDrv.h"
 #ifdef Q_OS_WIN
 #include "rig/drivers/OmnirigRigDrv.h"
@@ -146,6 +149,31 @@ void Rig::stopTimer()
     FCT_IDENTIFICATION;
     bool check = QMetaObject::invokeMethod(Rig::instance(), &Rig::stopTimerImplt,
                                            Qt::QueuedConnection);
+    Q_ASSERT( check );
+}
+
+void Rig::shutdown()
+{
+    FCT_IDENTIFICATION;
+
+    if ( QThread::currentThread() == thread() )
+    {
+        closeImpl();
+        stopTimerImplt();
+        return;
+    }
+
+    if ( !thread() || !thread()->isRunning() )
+    {
+        qCWarning(runtime) << "Cannot synchronously shut down Rig because owner thread is not running";
+        return;
+    }
+
+    bool check = QMetaObject::invokeMethod(this, [this]()
+    {
+        closeImpl();
+        stopTimerImplt();
+    }, Qt::BlockingQueuedConnection);
     Q_ASSERT( check );
 }
 
@@ -759,7 +787,17 @@ Rig::~Rig()
 {
     FCT_IDENTIFICATION;
 
-    __closeRig();
+    if ( !rigDriver && !rigctldManager )
+        return;
+
+    if ( QThread::currentThread() == thread() )
+    {
+        __closeRig();
+    }
+    else
+    {
+        qCWarning(runtime) << "Skipping Rig shutdown from non-owner thread";
+    }
 }
 
 void Rig::sendHeartBeat()

--- a/rig/Rig.cpp
+++ b/rig/Rig.cpp
@@ -2,6 +2,9 @@
 #include "RigctldManager.h"
 #include "core/debug.h"
 
+#include <QAtomicInt>
+#include <QSemaphore>
+#include <QSharedPointer>
 #include <QThread>
 
 #include "rig/drivers/HamlibRigDrv.h"
@@ -158,23 +161,45 @@ void Rig::shutdown()
 
     if ( QThread::currentThread() == thread() )
     {
-        closeImpl();
-        stopTimerImplt();
+        shutdownImpl();
         return;
     }
 
     if ( !thread() || !thread()->isRunning() )
     {
-        qCWarning(runtime) << "Cannot synchronously shut down Rig because owner thread is not running";
+        qCWarning(runtime) << "Cannot shut down Rig because owner thread is not running";
         return;
     }
 
-    bool check = QMetaObject::invokeMethod(this, [this]()
+    QSharedPointer<QSemaphore> shutdownDone = QSharedPointer<QSemaphore>::create();
+    QSharedPointer<QAtomicInt> shutdownCanceled = QSharedPointer<QAtomicInt>::create(0);
+    bool check = QMetaObject::invokeMethod(this, [this, shutdownDone, shutdownCanceled]()
     {
-        closeImpl();
-        stopTimerImplt();
-    }, Qt::BlockingQueuedConnection);
-    Q_ASSERT( check );
+        if ( !shutdownCanceled->loadAcquire() )
+        {
+            shutdownImpl();
+        }
+        shutdownDone->release();
+    }, Qt::QueuedConnection);
+    if ( !check )
+    {
+        qCWarning(runtime) << "Failed to queue Rig shutdown";
+        return;
+    }
+
+    if ( !shutdownDone->tryAcquire(1, SHUTDOWN_TIMEOUT_MS) )
+    {
+        shutdownCanceled->storeRelease(1);
+        qCWarning(runtime) << "Rig shutdown timed out";
+    }
+}
+
+void Rig::shutdownImpl()
+{
+    FCT_IDENTIFICATION;
+
+    closeImpl();
+    stopTimerImplt();
 }
 
 void Rig::stopTimerImplt()

--- a/rig/Rig.h
+++ b/rig/Rig.h
@@ -91,6 +91,7 @@ public slots:
     void start();
     void open();
     void close();
+    void shutdown();
     void stopTimer();
 
     void setFrequency(double);

--- a/rig/Rig.h
+++ b/rig/Rig.h
@@ -127,6 +127,7 @@ signals:
 
 private slots:
     void stopTimerImplt();
+    void shutdownImpl();
     void openImpl();
     void closeImpl();
 
@@ -186,6 +187,7 @@ private:
     QTimer *heartBeatTimer;
     const quint16 HEARTBEATPERIOD = 1000; // in ms
     RigctldManager *rigctldManager = nullptr;
+    static const int SHUTDOWN_TIMEOUT_MS = 5000;
 };
 
 Q_DECLARE_METATYPE(Rig::Status);

--- a/rig/RigctldManager.cpp
+++ b/rig/RigctldManager.cpp
@@ -20,7 +20,15 @@ RigctldManager::RigctldManager(QObject *parent)
 RigctldManager::~RigctldManager()
 {
     FCT_IDENTIFICATION;
-    stop();
+
+    if ( thread() == QThread::currentThread() )
+    {
+        stop();
+    }
+    else if ( rigctldProcess )
+    {
+        qCWarning(runtime) << "Skipping rigctld shutdown from non-owner thread";
+    }
 }
 
 bool RigctldManager::start(const RigProfile &profile)
@@ -134,28 +142,30 @@ void RigctldManager::stop()
 {
     FCT_IDENTIFICATION;
 
-    if ( !rigctldProcess ) return;
+    if ( !rigctldProcess || stoppingInProgress ) return;
 
     stoppingInProgress = true;
 
-    if ( rigctldProcess->state() != QProcess::NotRunning )
+    QProcess *process = rigctldProcess;
+    rigctldProcess = nullptr;
+
+    // During a normal stop, stop receiving this process's signals here. Leave
+    // any other QProcess connections alone.
+    disconnect(process, nullptr, this, nullptr);
+
+    if ( process->state() != QProcess::NotRunning )
     {
         qCDebug(runtime) << "Stopping rigctld";
-
-        // Disconnect signals to prevent error notifications during controlled shutdown
-        rigctldProcess->disconnect();
-
-        rigctldProcess->terminate();
-        if ( !rigctldProcess->waitForFinished(3000) )
+        process->terminate();
+        if ( !process->waitForFinished(3000) )
         {
             qCWarning(runtime) << "rigctld did not terminate gracefully, killing";
-            rigctldProcess->kill();
-            rigctldProcess->waitForFinished(1000);
+            process->kill();
+            process->waitForFinished(1000);
         }
     }
 
-    delete rigctldProcess;
-    rigctldProcess = nullptr;
+    delete process;
     stoppingInProgress = false;
 
     emit stopped();

--- a/rotator/Rotator.cpp
+++ b/rotator/Rotator.cpp
@@ -2,6 +2,7 @@
 #include "core/debug.h"
 #include "rotator/drivers/HamlibRotDrv.h"
 #include "rotator/drivers/PSTRotDrv.h"
+#include <QThread>
 
 MODULE_IDENTIFICATION("qlog.rotator.rotator");
 
@@ -35,7 +36,17 @@ Rotator::~Rotator()
 {
     FCT_IDENTIFICATION;
 
+    if ( !rotDriver )
+        return;
+
+    if ( QThread::currentThread() != thread() )
+    {
+        qCWarning(runtime) << "Skipping Rotator shutdown from non-owner thread";
+        return;
+    }
+
     __closeRot();
+    stopTimerImplt();
 }
 
 double Rotator::getAzimuth()
@@ -111,6 +122,31 @@ void Rotator::stopTimer()
     bool check = QMetaObject::invokeMethod(Rotator::instance(),
                                            &Rotator::stopTimerImplt,
                                            Qt::QueuedConnection);
+    Q_ASSERT( check );
+}
+
+void Rotator::shutdown()
+{
+    FCT_IDENTIFICATION;
+
+    if ( QThread::currentThread() == thread() )
+    {
+        closeImpl();
+        stopTimerImplt();
+        return;
+    }
+
+    if ( !thread() || !thread()->isRunning() )
+    {
+        qCWarning(runtime) << "Cannot synchronously shut down Rotator because owner thread is not running";
+        return;
+    }
+
+    bool check = QMetaObject::invokeMethod(this, [this]()
+    {
+        closeImpl();
+        stopTimerImplt();
+    }, Qt::BlockingQueuedConnection);
     Q_ASSERT( check );
 }
 

--- a/rotator/Rotator.cpp
+++ b/rotator/Rotator.cpp
@@ -2,6 +2,9 @@
 #include "core/debug.h"
 #include "rotator/drivers/HamlibRotDrv.h"
 #include "rotator/drivers/PSTRotDrv.h"
+#include <QAtomicInt>
+#include <QSemaphore>
+#include <QSharedPointer>
 #include <QThread>
 
 MODULE_IDENTIFICATION("qlog.rotator.rotator");
@@ -131,23 +134,45 @@ void Rotator::shutdown()
 
     if ( QThread::currentThread() == thread() )
     {
-        closeImpl();
-        stopTimerImplt();
+        shutdownImpl();
         return;
     }
 
     if ( !thread() || !thread()->isRunning() )
     {
-        qCWarning(runtime) << "Cannot synchronously shut down Rotator because owner thread is not running";
+        qCWarning(runtime) << "Cannot shut down Rotator because owner thread is not running";
         return;
     }
 
-    bool check = QMetaObject::invokeMethod(this, [this]()
+    QSharedPointer<QSemaphore> shutdownDone = QSharedPointer<QSemaphore>::create();
+    QSharedPointer<QAtomicInt> shutdownCanceled = QSharedPointer<QAtomicInt>::create(0);
+    bool check = QMetaObject::invokeMethod(this, [this, shutdownDone, shutdownCanceled]()
     {
-        closeImpl();
-        stopTimerImplt();
-    }, Qt::BlockingQueuedConnection);
-    Q_ASSERT( check );
+        if ( !shutdownCanceled->loadAcquire() )
+        {
+            shutdownImpl();
+        }
+        shutdownDone->release();
+    }, Qt::QueuedConnection);
+    if ( !check )
+    {
+        qCWarning(runtime) << "Failed to queue Rotator shutdown";
+        return;
+    }
+
+    if ( !shutdownDone->tryAcquire(1, SHUTDOWN_TIMEOUT_MS) )
+    {
+        shutdownCanceled->storeRelease(1);
+        qCWarning(runtime) << "Rotator shutdown timed out";
+    }
+}
+
+void Rotator::shutdownImpl()
+{
+    FCT_IDENTIFICATION;
+
+    closeImpl();
+    stopTimerImplt();
 }
 
 void Rotator::stopTimerImplt()

--- a/rotator/Rotator.h
+++ b/rotator/Rotator.h
@@ -42,6 +42,7 @@ public slots:
     void start();
     void open();
     void close();
+    void shutdown();
     void stopTimer();
 
     void sendState();

--- a/rotator/Rotator.h
+++ b/rotator/Rotator.h
@@ -51,6 +51,7 @@ public slots:
 private slots:
     void setPositionImpl(double azimuth, double elevation);
     void stopTimerImplt();
+    void shutdownImpl();
     void openImpl();
     void closeImpl();
     void sendStateImpl();
@@ -97,6 +98,7 @@ private:
     bool connected;
     double cacheAzimuth;
     double cacheElevation;
+    static const int SHUTDOWN_TIMEOUT_MS = 5000;
 };
 
 #endif // QLOG_ROTATOR_ROTATOR_H

--- a/tests/RigctldManagerTest/tst_rigctldmanager.cpp
+++ b/tests/RigctldManagerTest/tst_rigctldmanager.cpp
@@ -32,6 +32,7 @@ private slots:
     void start_failsWithInvalidProfile();
     void getConnectHost_returnsLocalhost();
     void getConnectPort_returnsConfiguredPort();
+    void stop_isIdempotentWithoutStart();
 
     // getVersion tests
     void getVersion_returnsInvalidForNonexistentPath();
@@ -40,6 +41,7 @@ private slots:
 
     // Integration test (skipped if rigctld not available)
     void start_stop_integration();
+    void destructor_afterStart_stopsProcess();
 
 private:
     QString findRigctld();
@@ -233,6 +235,18 @@ void RigctldManagerTest::getConnectPort_returnsConfiguredPort()
     QCOMPARE(manager.getConnectPort(), static_cast<quint16>(4532));
 }
 
+void RigctldManagerTest::stop_isIdempotentWithoutStart()
+{
+    RigctldManager manager;
+    QSignalSpy stoppedSpy(&manager, &RigctldManager::stopped);
+
+    manager.stop();
+    manager.stop();
+
+    QVERIFY(!manager.isRunning());
+    QCOMPARE(stoppedSpy.count(), 0);
+}
+
 // ============================================================================
 // getVersion tests
 // ============================================================================
@@ -321,12 +335,52 @@ void RigctldManagerTest::start_stop_integration()
 
     // Stop
     manager.stop();
+    manager.stop();
     QVERIFY(!manager.isRunning());
+    QCOMPARE(stoppedSpy.count(), 1);
 
     // Verify port is no longer listening
     QTcpSocket socket2;
     socket2.connectToHost("127.0.0.1", 14534);
     bool stillConnected = socket2.waitForConnected(1000);
+    QVERIFY(!stillConnected);
+}
+
+void RigctldManagerTest::destructor_afterStart_stopsProcess()
+{
+    if (!rigctldAvailable)
+    {
+        QSKIP("rigctld not available for integration test");
+    }
+
+    constexpr quint16 testPort = 14535;
+
+    {
+        RigctldManager manager;
+        QSignalSpy errorSpy(&manager, &RigctldManager::errorOccurred);
+
+        RigProfile profile;
+        profile.model = 1;  // Dummy rig (Hamlib model 1 = Dummy)
+        profile.rigctldPort = testPort;
+        profile.rigctldPath = rigctldPath;
+
+        bool result = manager.start(profile);
+
+        if (!result)
+        {
+            if (!errorSpy.isEmpty())
+            {
+                qWarning() << "Start failed with error:" << errorSpy.first().first().toString();
+            }
+            QSKIP("Could not start rigctld with dummy rig");
+        }
+
+        QVERIFY(manager.isRunning());
+    }
+
+    QTcpSocket socket;
+    socket.connectToHost("127.0.0.1", testPort);
+    bool stillConnected = socket.waitForConnected(1000);
     QVERIFY(!stillConnected);
 }
 

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -2090,14 +2090,15 @@ MainWindow::~MainWindow()
 
     //saveEquipmentConnOptions();
 
-    Rig::instance()->close();
-    Rotator::instance()->close();
-    CWKeyer::instance()->close();
-    QThread::msleep(500);
+    // These singletons live on worker threads. Disconnect them before shutdown
+    // so queued signals cannot land on widgets that are about to be deleted.
+    QObject::disconnect(CWKeyer::instance(), nullptr, nullptr, nullptr);
+    QObject::disconnect(Rotator::instance(), nullptr, nullptr, nullptr);
+    QObject::disconnect(Rig::instance(), nullptr, nullptr, nullptr);
 
-    Rig::instance()->stopTimer();
-    Rotator::instance()->stopTimer();
-    CWKeyer::instance()->stopTimer();
+    CWKeyer::instance()->shutdown();
+    Rotator::instance()->shutdown();
+    Rig::instance()->shutdown();
 
     conditions->deleteLater();
     conditionsLabel->deleteLater();


### PR DESCRIPTION
## Summary
This fixes an intermittent crash I saw when closing QLog on Windows with rigctld
sharing enabled. The crash was in `RigctldManager::stop()`, called from
`Rig::~Rig()`, while `QProcess::waitForFinished()` was running.

The old shutdown path queued Rig, Rotator, and CWKeyer cleanup to their worker
threads, then slept for a fixed amount of time before the rest of QLog shut down.
That could leave device cleanup racing Qt/application teardown.

This change makes shutdown explicit:
- disconnect station-device signals before the UI is destroyed
- shut down CWKeyer, Rotator, then Rig on their worker threads
- join the worker threads after `app.exec()` returns
- make `RigctldManager::stop()` safe to call more than once
- avoid deleting a still-running `QThread` if shutdown times out
## Validation
- Fresh MSVC build: PASSED
- `RigctldManagerTest`: PASSED
- QLog launch/close smoke test: PASSED
- rigctld-sharing close test: PASSED
- 
## Notes
I tested the Rig/rigctld path locally. I do not have Rotator or CWKeyer hardware,
so those paths follow the same shutdown pattern but have not been tested with
real hardware.