### PR TITLE
Fix WSJT-X QSO panel mode updates

### DIFF
--- a/core/WsjtxUDPReceiver.cpp
+++ b/core/WsjtxUDPReceiver.cpp
@@ -287,7 +287,7 @@ void WsjtxUDPReceiver::readPendingDatagrams()
 
             status.id = QString(id);
             status.mode = QString(mode);
-            status.tx_mode = QString(mode);
+            status.tx_mode = QString(tx_mode);
             status.sub_mode = QString(sub_mode);
             status.report = QString(report);
             status.dx_call = QString(dx_call);

--- a/ui/WsjtxWidget.cpp
+++ b/ui/WsjtxWidget.cpp
@@ -209,14 +209,17 @@ void WsjtxWidget::statusReceived(WsjtxStatus newStatus)
         clearTable();
     }
 
+    const QString wsjtxMode = ( !newStatus.tx_mode.isEmpty() ) ? newStatus.tx_mode
+                                                               : newStatus.mode;
+    const QPair<QString, QString>& legacy = Data::instance()->legacyMode(wsjtxMode);
+    QString mode = ( !legacy.first.isEmpty() ) ? legacy.first
+                                               : wsjtxMode.toUpper();
+    QString submode = ( !legacy.first.isEmpty() ) ? legacy.second
+                                                  : QString();
+    emit modeChanged(VFO1, wsjtxMode, mode, submode, 0);
+
     if ( !Rig::instance()->isRigConnected() )
     {
-        const QPair<QString, QString>& legacy = Data::instance()->legacyMode(newStatus.mode);
-        QString mode = ( !legacy.first.isEmpty() ) ? legacy.first
-                                                   : newStatus.mode.toUpper();
-        QString submode = ( !legacy.first.isEmpty() ) ? legacy.second
-                                                      : QString();
-        emit modeChanged(VFO1, newStatus.mode, mode, submode, 0);
         emit frequencyChanged(VFO1, currFreq, currFreq, currFreq);
     }
 


### PR DESCRIPTION
WSJT-X sends QLog both the current decode mode and the TX/logging mode in its
Status message. For the New Contact panel, the TX/logging mode is the one that
matters: it is the mode WSJT-X will use for the QSO, and it affects things like
worked-before checks.

This fixes two small issues in that path:

- `tx_mode` was parsed, but `status.tx_mode` was accidentally filled with
  `mode`, so the actual TX mode was lost.
- WSJT-X mode changes were only sent to the New Contact panel when no rig was
  connected. With a rig connected, the panel could keep the rig's data mode
  instead of the WSJT-X QSO mode.

The WSJT-X spot table is unchanged. This only changes the New Contact panel:
it now uses WSJT-X's TX/logging mode for the QSO mode.