### PR TITLE
Handle null dbField when saving template columns

### DIFF
--- a/ui/CabrilloTemplateDialog.cpp
+++ b/ui/CabrilloTemplateDialog.cpp
@@ -587,9 +587,11 @@ bool CabrilloTemplateDialog::saveTemplateColumns(QSqlQuery &query, int templateI
 
     for ( const CabrilloFormat::ColumnDef &col : columns )
     {
+        const QString dbField = col.dbField.isNull() ? "" : col.dbField;
+
         query.bindValue(":tid", templateId);
         query.bindValue(":pos", col.position);
-        query.bindValue(":field", col.dbField);
+        query.bindValue(":field", dbField);
         query.bindValue(":width", col.width);
         query.bindValue(":fmt", col.formatter);
         query.bindValue(":label", col.label);


### PR DESCRIPTION
#1077 In saveTemplateColumns (ui/CabrilloTemplateDialog.cpp) ensure col.dbField is converted to an empty string when null before binding to the SQL query. This prevents passing a null QString to the :field parameter, avoiding potential DB errors for columns without a defined dbField.