### PR TITLE
ADIF UDP listener and settings

### DIFF
--- a/QLog.pro
+++ b/QLog.pro
@@ -78,6 +78,7 @@ SOURCES += \
         awards/AwardWPX.cpp \
         awards/AwardWWFF.cpp \
         awards/BandTableAward.cpp \
+        core/AdifUDPReceiver.cpp \
         core/AlertEvaluator.cpp \
         core/AdifRecovery.cpp \
         core/AppGuard.cpp \
@@ -263,6 +264,7 @@ HEADERS += \
         awards/AwardWPX.h \
         awards/AwardWWFF.h \
         awards/BandTableAward.h \
+        core/AdifUDPReceiver.h \
         core/AlertEvaluator.h \
         core/AdifRecovery.h \
         core/AppGuard.h \

--- a/core/AdifUDPReceiver.cpp
+++ b/core/AdifUDPReceiver.cpp
@@ -1,0 +1,219 @@
+#include <QUdpSocket>
+#include <QNetworkDatagram>
+#include <QHostAddress>
+#include <QSqlTableModel>
+#include <QTextStream>
+
+#include "AdifUDPReceiver.h"
+#include "core/LogParam.h"
+#include "core/debug.h"
+#include "logformat/AdiFormat.h"
+
+MODULE_IDENTIFICATION("qlog.core.adifudp");
+
+AdifUDPReceiver::AdifUDPReceiver(QObject *parent) :
+    QObject(parent),
+    socket(new QUdpSocket(this))
+{
+    FCT_IDENTIFICATION;
+
+    connect(socket, &QUdpSocket::readyRead, this, &AdifUDPReceiver::readPendingDatagrams);
+    reloadSetting();
+}
+
+quint16 AdifUDPReceiver::getConfigPort()
+{
+    FCT_IDENTIFICATION;
+
+    const quint16 ret = LogParam::getNetworkAdifListenerPort(DEFAULT_PORT);
+
+    qCDebug(runtime) << "ADIF UDP configured port" << ret;
+
+    return ret;
+}
+
+void AdifUDPReceiver::saveConfigPort(quint16 port)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(function_parameters) << port;
+
+    LogParam::setNetworkAdifListenerPort(port);
+}
+
+bool AdifUDPReceiver::getConfigEnabled()
+{
+    FCT_IDENTIFICATION;
+
+    const bool ret = LogParam::getNetworkAdifListenerEnabled();
+
+    qCDebug(runtime) << "ADIF UDP listener enabled" << ret;
+
+    return ret;
+}
+
+void AdifUDPReceiver::saveConfigEnabled(bool enabled)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(function_parameters) << enabled;
+
+    LogParam::setNetworkAdifListenerEnabled(enabled);
+}
+
+void AdifUDPReceiver::reloadSetting()
+{
+    FCT_IDENTIFICATION;
+
+    const bool enabled = getConfigEnabled();
+
+    qCDebug(runtime) << "Reloading ADIF UDP listener settings; enabled" << enabled;
+
+    if ( enabled )
+        openPort();
+    else
+        closePort();
+}
+
+void AdifUDPReceiver::openPort()
+{
+    FCT_IDENTIFICATION;
+
+    if ( !socket )
+    {
+        qWarning() << "Cannot open ADIF UDP port - socket is not initialized";
+        return;
+    }
+
+    if ( socket->state() == QAbstractSocket::BoundState )
+    {
+        qCDebug(runtime) << "Closing previously bound ADIF UDP port";
+        socket->close();
+    }
+
+    const quint16 newPort = getConfigPort();
+
+    qCDebug(runtime) << "ADIF UDP listen port" << newPort;
+
+    if ( !socket->bind(QHostAddress::Any, newPort) )
+    {
+        qWarning() << "Cannot bind the Port for ADIF UDP";
+        return;
+    }
+
+    qCDebug(runtime) << "ADIF UDP listening on all interfaces";
+}
+
+void AdifUDPReceiver::closePort()
+{
+    FCT_IDENTIFICATION;
+
+    if ( socket && socket->state() == QAbstractSocket::BoundState )
+    {
+        qCDebug(runtime) << "Closing ADIF UDP listener";
+        socket->close();
+    }
+    else
+    {
+        qCDebug(runtime) << "ADIF UDP listener is already closed";
+    }
+}
+
+void AdifUDPReceiver::readPendingDatagrams()
+{
+    FCT_IDENTIFICATION;
+
+    while ( socket->hasPendingDatagrams() )
+    {
+        const QNetworkDatagram datagram = socket->receiveDatagram();
+        qCDebug(runtime) << "Received ADIF UDP datagram from" << datagram.senderAddress()
+                         << datagram.senderPort()
+                         << "bytes" << datagram.data().size();
+        processDatagram(datagram.data());
+    }
+}
+
+void AdifUDPReceiver::processDatagram(const QByteArray &data)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(function_parameters) << "bytes" << data.size();
+
+    QString adif = QString::fromUtf8(data);
+    if ( adif.isEmpty() )
+    {
+        qCDebug(runtime) << "ADIF UDP datagram is not valid UTF-8, trying Latin-1";
+        adif = QString::fromLatin1(data);
+    }
+
+    const int start = adif.indexOf(QLatin1Char('<'));
+    if ( start < 0 )
+    {
+        qWarning() << "Ignoring ADIF UDP datagram without ADIF tags";
+        return;
+    }
+
+    if ( start > 0 )
+        qCDebug(runtime) << "Skipping ADIF UDP datagram prefix bytes" << start;
+
+    emitRecords(adif.mid(start));
+}
+
+void AdifUDPReceiver::emitRecords(const QString &adif)
+{
+    FCT_IDENTIFICATION;
+
+    qCDebug(function_parameters) << "characters" << adif.size();
+
+    QString input(adif);
+    QTextStream in(&input);
+    AdiFormat adi(in);
+
+    QSqlTableModel model;
+    model.setTable("contacts");
+    model.removeColumn(model.fieldIndex("id"));
+
+    bool imported = false;
+    int recordCount = 0;
+    while ( true )
+    {
+        QSqlRecord record = model.record(0);
+        if ( !adi.importNext(record) )
+            break;
+
+        if ( record.value("callsign").toString().isEmpty() )
+        {
+            qWarning() << "Ignoring ADIF UDP record without callsign" << record;
+            continue;
+        }
+
+        const int qslSentIndex = record.indexOf("qsl_sent");
+        if ( qslSentIndex >= 0 )
+            record.remove(qslSentIndex);
+
+        const int lotwQslSentIndex = record.indexOf("lotw_qsl_sent");
+        if ( lotwQslSentIndex >= 0 )
+            record.remove(lotwQslSentIndex);
+
+        const int eqslQslSentIndex = record.indexOf("eqsl_qsl_sent");
+        if ( eqslQslSentIndex >= 0 )
+            record.remove(eqslQslSentIndex);
+
+        qCDebug(runtime) << "Emitting ADIF UDP contact"
+                         << record.value("callsign").toString()
+                         << record.value("start_time")
+                         << record.value("freq")
+                         << record.value("band")
+                         << record.value("mode");
+        qCDebug(function_parameters) << record;
+
+        emit addContact(record);
+        imported = true;
+        recordCount++;
+    }
+
+    if ( !imported )
+        qWarning() << "ADIF UDP datagram did not contain an importable QSO record";
+    else
+        qCDebug(runtime) << "Imported ADIF UDP records" << recordCount;
+}

--- a/core/AdifUDPReceiver.h
+++ b/core/AdifUDPReceiver.h
@@ -1,0 +1,40 @@
+#ifndef QLOG_CORE_ADIFUDPRECEIVER_H
+#define QLOG_CORE_ADIFUDPRECEIVER_H
+
+#include <QObject>
+#include <QSqlRecord>
+
+class QUdpSocket;
+
+class AdifUDPReceiver : public QObject
+{
+    Q_OBJECT
+public:
+    explicit AdifUDPReceiver(QObject *parent = nullptr);
+
+    static quint16 getConfigPort();
+    static void saveConfigPort(quint16 port);
+    static bool getConfigEnabled();
+    static void saveConfigEnabled(bool enabled);
+
+signals:
+    void addContact(QSqlRecord record);
+
+public slots:
+    void reloadSetting();
+
+private slots:
+    void readPendingDatagrams();
+
+private:
+    void openPort();
+    void closePort();
+    void processDatagram(const QByteArray &data);
+    void emitRecords(const QString &adif);
+
+    QUdpSocket *socket;
+
+    static const int DEFAULT_PORT = 2333;
+};
+
+#endif // QLOG_CORE_ADIFUDPRECEIVER_H

--- a/core/LogParam.cpp
+++ b/core/LogParam.cpp
@@ -777,6 +777,26 @@ void LogParam::setNetworkWsjtxListenerMulticastTTL(int ttl)
     setParam("network/listener/wsjtx/multicast/ttl", ttl);
 }
 
+bool LogParam::getNetworkAdifListenerEnabled()
+{
+    return getParam("network/listener/adif/enabled", false).toBool();
+}
+
+void LogParam::setNetworkAdifListenerEnabled(bool state)
+{
+    setParam("network/listener/adif/enabled", state);
+}
+
+int LogParam::getNetworkAdifListenerPort(int defaultPort)
+{
+    return getParam("network/listener/adif/port", defaultPort).toInt();
+}
+
+void LogParam::setNetworkAdifListenerPort(int port)
+{
+    setParam("network/listener/adif/port", port);
+}
+
 QStringList LogParam::getEnabledMemberlists()
 {
     return getParamStringList("memberlist/enabledlists");

--- a/core/LogParam.h
+++ b/core/LogParam.h
@@ -243,6 +243,10 @@ public:
     static void setNetworkWsjtxListenerMulticastAddr(const QString &addr);
     static int getNetworkWsjtxListenerMulticastTTL();
     static void setNetworkWsjtxListenerMulticastTTL(int ttl);
+    static bool getNetworkAdifListenerEnabled();
+    static void setNetworkAdifListenerEnabled(bool state);
+    static int getNetworkAdifListenerPort(int defaultPort);
+    static void setNetworkAdifListenerPort(int port);
 
     /********************
      * Club Member Lists

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -23,6 +23,7 @@
 #include "rotator/Rotator.h"
 #include "cwkey/CWKeyer.h"
 #include "core/WsjtxUDPReceiver.h"
+#include "core/AdifUDPReceiver.h"
 #include "core/debug.h"
 #include "ui/NewContactWidget.h"
 #include "ui/QSOFilterDialog.h"
@@ -69,7 +70,9 @@ MainWindow::MainWindow(QWidget* parent) :
     ui(new Ui::MainWindow),
     stats(new StatisticsWidget),
     clublogRT(new ClubLogUploader(this)),
-    adifRecoveryManager(new AdifRecoveryManager(this))
+    adifRecoveryManager(new AdifRecoveryManager(this)),
+    wsjtx(nullptr),
+    adifUDP(nullptr)
 {
     FCT_IDENTIFICATION;
 
@@ -299,6 +302,9 @@ MainWindow::MainWindow(QWidget* parent) :
     FldigiTCPServer* fldigi = new FldigiTCPServer(this);
     connect(fldigi, &FldigiTCPServer::addContact, ui->newContactWidget, &NewContactWidget::saveExternalContact);
 
+    adifUDP = new AdifUDPReceiver(this);
+    connect(adifUDP, &AdifUDPReceiver::addContact, ui->newContactWidget, &NewContactWidget::saveExternalContact);
+
     connect(adifRecoveryManager, &AdifRecoveryManager::contactsRecovered, ui->logbookWidget, &LogbookWidget::updateTable);
     connect(adifRecoveryManager, &AdifRecoveryManager::problem, this, [this](const QString &message)
     {
@@ -325,6 +331,7 @@ MainWindow::MainWindow(QWidget* parent) :
     connect(ui->wsjtxWidget, &WsjtxWidget::modeChanged, ui->newContactWidget, &NewContactWidget::changeModefromRig);
 
     connect(this, &MainWindow::settingsChanged, wsjtx, &WsjtxUDPReceiver::reloadSetting);
+    connect(this, &MainWindow::settingsChanged, adifUDP, &AdifUDPReceiver::reloadSetting);
     connect(this, &MainWindow::settingsChanged, adifRecoveryManager, &AdifRecoveryManager::reloadSettings);
     connect(this, &MainWindow::settingsChanged, ui->rotatorWidget, &RotatorWidget::reloadSettings);
     connect(this, &MainWindow::settingsChanged, ui->rigWidget, &RigWidget::reloadSettings);
@@ -2251,6 +2258,8 @@ MainWindow::~MainWindow()
     clublogRT->deleteLater();
     if ( wsjtx )
         wsjtx->deleteLater();
+    if ( adifUDP )
+        adifUDP->deleteLater();
 
     seqGroup->deleteLater();
     dupeGroup->deleteLater();

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -16,6 +16,7 @@ class MainWindow;
 
 class QLabel;
 class WsjtxUDPReceiver;
+class AdifUDPReceiver;
 class AdifRecoveryManager;
 
 class MainWindow : public QMainWindow {
@@ -121,6 +122,7 @@ private:
     ClubLogUploader* clublogRT;
     AdifRecoveryManager* adifRecoveryManager;
     WsjtxUDPReceiver* wsjtx;
+    AdifUDPReceiver* adifUDP;
     QActionGroup *seqGroup;
     QActionGroup *dupeGroup;
     QActionGroup *linkExchangeGroup;

--- a/ui/SettingsDialog.cpp
+++ b/ui/SettingsDialog.cpp
@@ -34,6 +34,7 @@
 #include "data/Data.h"
 #include "data/Gridsquare.h"
 #include "core/WsjtxUDPReceiver.h"
+#include "core/AdifUDPReceiver.h"
 #include "core/NetworkNotification.h"
 #include "rig/Rig.h"
 #include "rig/RigCaps.h"
@@ -684,6 +685,15 @@ void SettingsDialog::save()
                                  QMessageBox::tr("Loop detected. Raw UDP forward uses the same port as the WSJT-X receiving port."));
             return;
         }
+    }
+
+    if ( ui->adifUdpEnabledCheckBox->isChecked()
+         && ui->adifUdpPortSpin->value() == ui->wsjtPortSpin->value() )
+    {
+        ui->tabWidget->setCurrentIndex(8);
+        QMessageBox::warning(nullptr, QMessageBox::tr("QLog Warning"),
+                             QMessageBox::tr("ADIF UDP Listener cannot use the same port as the WSJT-X receiving port."));
+        return;
     }
 
     writeSettings();
@@ -2754,6 +2764,8 @@ void SettingsDialog::readSettings()
     ui->wsjtMulticastAddressEdit->setText(WsjtxUDPReceiver::getConfigMulticastAddress());
     ui->wsjtMulticastTTLSpin->setValue(WsjtxUDPReceiver::getConfigMulticastTTL());
     ui->wsjtColorCqSpotsCheckbox->setChecked(WsjtxUDPReceiver::getConfigOutputColorCQSpot());
+    ui->adifUdpEnabledCheckBox->setChecked(AdifUDPReceiver::getConfigEnabled());
+    ui->adifUdpPortSpin->setValue(AdifUDPReceiver::getConfigPort());
 
     ui->notifLogIDEdit->setText(LogParam::getLogID());
     ui->notifQSOEdit->setText(NetworkNotification::getNotifQSOAdiAddrs());
@@ -2893,6 +2905,8 @@ void SettingsDialog::writeSettings()
     WsjtxUDPReceiver::saveConfigMulticastAddress(ui->wsjtMulticastAddressEdit->text());
     WsjtxUDPReceiver::saveConfigMulticastTTL(ui->wsjtMulticastTTLSpin->value());
     WsjtxUDPReceiver::saveConfigOutputColorCQSpot(ui->wsjtColorCqSpotsCheckbox->isChecked());
+    AdifUDPReceiver::saveConfigEnabled(ui->adifUdpEnabledCheckBox->isChecked());
+    AdifUDPReceiver::saveConfigPort(ui->adifUdpPortSpin->value());
     NetworkNotification::saveNotifQSOAdiAddrs(ui->notifQSOEdit->text());
     NetworkNotification::saveNotifDXSpotAddrs(ui->notifDXSpotsEdit->text());
     NetworkNotification::saveNotifWSJTXCQSpotAddrs(ui->notifWSJTXCQSpotsEdit->text());

--- a/ui/SettingsDialog.ui
+++ b/ui/SettingsDialog.ui
@@ -4652,6 +4652,61 @@
            </widget>
           </item>
          </layout>
+       </widget>
+      </item>
+       <item>
+        <widget class="QGroupBox" name="adifUdpGroupBox">
+         <property name="title">
+          <string>ADIF UDP Listener</string>
+         </property>
+         <layout class="QFormLayout" name="adifUdpFormLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="adifUdpEnabledLabel">
+            <property name="text">
+             <string>Enabled</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="adifUdpEnabledCheckBox">
+            <property name="toolTip">
+             <string>Enable/Disable receiving ADIF log records from other applications over UDP</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="adifUdpPortLabel">
+            <property name="text">
+             <string>Port</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="adifUdpPortSpin">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Port where QLog listens for incoming UDP ADIF log records</string>
+            </property>
+            <property name="minimum">
+             <number>1025</number>
+            </property>
+            <property name="maximum">
+             <number>65534</number>
+            </property>
+            <property name="value">
+             <number>2333</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
Introduce AdifUDPReceiver to listen for ADIF records over UDP (default port 2333), parse incoming datagrams, and emit addContact(QSqlRecord) for import. Add LogParam getters/setters for enabling/port configuration. Integrate the receiver into MainWindow (construction, signal connections, reload on settings change, teardown). Add UI controls and validation in SettingsDialog to configure the ADIF UDP listener (enable + port) and prevent port conflict with WSJT-X. Update QLog.pro to include new sources/headers.