### PR TITLE
LoTW QSL Download New Option

### DIFF
--- a/logformat/LogFormat.cpp
+++ b/logformat/LogFormat.cpp
@@ -1217,14 +1217,21 @@ void LogFormat::runQSLImport(QSLFrom fromService)
         const QString startTimeStr = start_time.toDateTime().toTimeZone(QTimeZone::utc()).toString("yyyy-MM-dd hh:mm:ss");
 
         // Common filter conditions — shared by all match attempts
-        const QString baseFilter = QString(
+        QString baseFilter = QString(
             "callsign=upper('%1') AND upper(band)=upper('%2') AND "
             "COALESCE(sat_name, '') = upper('%3') AND "
-            "ABS(JULIANDAY(start_time)-JULIANDAY(datetime('%4')))*24*60<30"
+            "ABS(JULIANDAY(start_time)-JULIANDAY(datetime('%4')))*24*60<30 "
         ).arg(call.toString(), band.toString(), satName.toString(), startTimeStr);
 
+        if (fromService == LOTW)
+        {
+            const QVariant &station_callsign = QSLRecord.value("station_callsign");
+            baseFilter = baseFilter + QString(" AND station_callsign = upper('%1') ").arg(station_callsign.toString());
+        }
+
+        qDebug() << baseFilter;
         // First attempt: exact mode match (used for eQSL; also the fast path for LoTW)
-        model.setFilter(baseFilter + QString(" AND upper(mode)=upper('%1')").arg(mode.toString()));
+        model.setFilter(baseFilter + QString(" AND upper(mode)=upper('%1')").arg(mode.toString()));        
         model.select();
 
         // LoTW fallback: LoTW confirms QSOs when both sides specify modes in the same

--- a/service/lotw/Lotw.cpp
+++ b/service/lotw/Lotw.cpp
@@ -438,6 +438,8 @@ void LotwQSLDownloader::receiveQSL(const QDate &start_date, bool qso_since, cons
     QList<QPair<QString, QString>> params;
     params.append(qMakePair(QString("qso_query"), QString("1")));
     params.append(qMakePair(QString("qso_qsldetail"), QString("yes")));
+    params.append(qMakePair(QString("qso_mydetail"),QString("yes")));
+    params.append(qMakePair(QString("qso_withown"),QString("yes")));
 
     const QString trimmedStationCallsign = station_callsign.trimmed();
     if ( !trimmedStationCallsign.isEmpty() )

--- a/service/lotw/Lotw.cpp
+++ b/service/lotw/Lotw.cpp
@@ -438,7 +438,10 @@ void LotwQSLDownloader::receiveQSL(const QDate &start_date, bool qso_since, cons
     QList<QPair<QString, QString>> params;
     params.append(qMakePair(QString("qso_query"), QString("1")));
     params.append(qMakePair(QString("qso_qsldetail"), QString("yes")));
-    params.append(qMakePair(QString("qso_owncall"), station_callsign));
+
+    const QString trimmedStationCallsign = station_callsign.trimmed();
+    if ( !trimmedStationCallsign.isEmpty() )
+        params.append(qMakePair(QString("qso_owncall"), trimmedStationCallsign));
 
     const QString &start = start_date.toString("yyyy-MM-dd");
 

--- a/ui/DownloadQSLDialog.cpp
+++ b/ui/DownloadQSLDialog.cpp
@@ -22,7 +22,9 @@ DownloadQSLDialog::DownloadQSLDialog(QWidget *parent)
     ui->setupUi(this);
 
     ui->lotwMyCallsignCombo->setModel(new SqlListModel("SELECT DISTINCT UPPER(station_callsign) "
-                                                       "FROM contacts ORDER BY station_callsign", "", ui->lotwMyCallsignCombo));
+                                                       "FROM contacts ORDER BY station_callsign",
+                                                       tr("All Callsigns"),
+                                                       ui->lotwMyCallsignCombo));
     ui->lotwDateEdit->setDisplayFormat(locale.formatDateShortWithYYYY());
     ui->eqslDateEdit->setDisplayFormat(locale.formatDateShortWithYYYY());
     ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("&Download"));
@@ -34,9 +36,15 @@ DownloadQSLDialog::DownloadQSLDialog(QWidget *parent)
     int index = ui->lotwMyCallsignCombo->findText(profile.callsign);
 
     if ( index >= 0 )
+    {
         ui->lotwMyCallsignCombo->setCurrentIndex(index);
+    }
     else
-        ui->lotwMyCallsignCombo->setCurrentText(LogParam::getDownloadQSLLoTWLastCall());
+    {
+        const QString lastCall = LogParam::getDownloadQSLLoTWLastCall();
+        const int lastCallIndex = ui->lotwMyCallsignCombo->findText(lastCall);
+        ui->lotwMyCallsignCombo->setCurrentIndex(lastCall.isEmpty() || lastCallIndex < 0 ? 0 : lastCallIndex);
+    }
 
     // Enable options based on the configuration
     if ( LotwBase::getUsername().isEmpty() )
@@ -119,6 +127,15 @@ void DownloadQSLDialog::saveDialogState()
     LogParam::setDownloadQSLeQSLLastProfile(ui->eqslQTHProfileEdit->text());
 }
 
+QString DownloadQSLDialog::selectedLotwCallsign() const
+{
+    FCT_IDENTIFICATION;
+
+    return (ui->lotwMyCallsignCombo->currentIndex() == 0)
+            ? QString()
+            : ui->lotwMyCallsignCombo->currentText();
+}
+
 void DownloadQSLDialog::prepareDownload(GenericQSLDownloader *service,
                                         const QString &serviceName,
                                         bool qslSinceActive,
@@ -199,10 +216,11 @@ void DownloadQSLDialog::downloadQSLs()
         {
             LotwQSLDownloader* lotw = new LotwQSLDownloader(this);
             bool qslSinceActive = ui->lotwDateTypeCombo->currentIndex() == 0;
+            const QString stationCallsign = selectedLotwCallsign();
             prepareDownload(lotw, "LoTW", qslSinceActive, "lotw");
-            LogParam::setDownloadQSLLoTWLastCall(ui->lotwMyCallsignCombo->currentText());
+            LogParam::setDownloadQSLLoTWLastCall(stationCallsign);
             LogParam::setDownloadQSLServiceLastQSOQSL("lotw", qslSinceActive);
-            lotw->receiveQSL(ui->lotwDateEdit->date(), !qslSinceActive, ui->lotwMyCallsignCombo->currentText());
+            lotw->receiveQSL(ui->lotwDateEdit->date(), !qslSinceActive, stationCallsign);
         });
 
     if ( downloadQueue.isEmpty() )

--- a/ui/DownloadQSLDialog.h
+++ b/ui/DownloadQSLDialog.h
@@ -26,6 +26,7 @@ private:
     void startNextDownload();
     void loadDialogState();
     void saveDialogState();
+    QString selectedLotwCallsign() const;
 
     Ui::DownloadQSLDialog *ui;
     LogLocale locale;


### PR DESCRIPTION
Added an 'All Callsigns' option to omit the callsign filter when downloading QSLs from LoTW.  This may provide a better option for stations who have multiple callsigns.  #1082 