### PR TITLE
Add ability to clear selected alerts

### DIFF
--- a/models/AlertTableModel.cpp
+++ b/models/AlertTableModel.cpp
@@ -1,5 +1,7 @@
 #include <QColor>
 #include <QSqlRecord>
+#include <algorithm>
+#include <functional>
 
 #include "AlertTableModel.h"
 #include "data/Data.h"
@@ -125,6 +127,25 @@ void AlertTableModel::clear()
     beginResetModel();
     alertList.clear();
     endResetModel();
+}
+
+void AlertTableModel::clearRows(const QList<int> &rows)
+{
+    QList<int> selectedRows = rows;
+
+    std::sort(selectedRows.begin(), selectedRows.end(), std::greater<int>());
+    selectedRows.erase(std::unique(selectedRows.begin(), selectedRows.end()), selectedRows.end());
+
+    QMutexLocker locker(&alertListMutex);
+    for ( const int row : selectedRows )
+    {
+        if ( row < 0 || row >= alertList.count() )
+            continue;
+
+        beginRemoveRows(QModelIndex(), row, row);
+        alertList.removeAt(row);
+        endRemoveRows();
+    }
 }
 
 const AlertTableModel::AlertTableRecord AlertTableModel::getTableRecord(const QModelIndex &index)

--- a/models/AlertTableModel.h
+++ b/models/AlertTableModel.h
@@ -44,6 +44,7 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     void addAlert(const SpotAlert &entry);
     void clear();
+    void clearRows(const QList<int> &rows);
     const AlertTableRecord getTableRecord(const QModelIndex& index);
     void aging(const int clear_interval_sec);
     void resetDupe();

--- a/ui/AlertWidget.cpp
+++ b/ui/AlertWidget.cpp
@@ -29,6 +29,7 @@ AlertWidget::AlertWidget(QWidget *parent) :
 
     ui->alertTableView->addAction(ui->actionEditRules);
     ui->alertTableView->addAction(ui->actionColumnVisibility);
+    ui->alertTableView->addAction(ui->actionClearSelected);
     ui->alertTableView->addAction(ui->actionClear);
 
     restoreTableHeaderState();
@@ -66,6 +67,23 @@ void AlertWidget::clearAllAlerts()
     FCT_IDENTIFICATION;
 
     alertTableModel->clear();
+    emit alertsCleared();
+}
+
+void AlertWidget::clearSelectedAlerts()
+{
+    FCT_IDENTIFICATION;
+
+    const QModelIndexList selectedRows = ui->alertTableView->selectionModel()->selectedRows();
+    QList<int> sourceRows;
+
+    for ( const QModelIndex &index : selectedRows )
+        sourceRows << proxyModel->mapToSource(index).row();
+
+    if ( sourceRows.isEmpty() )
+        return;
+
+    alertTableModel->clearRows(sourceRows);
     emit alertsCleared();
 }
 

--- a/ui/AlertWidget.h
+++ b/ui/AlertWidget.h
@@ -25,6 +25,7 @@ public:
 public slots:
     void addAlert(const SpotAlert &alert);
     void clearAllAlerts();
+    void clearSelectedAlerts();
     void entryDoubleClicked(QModelIndex index);
     void alertAgingChanged(int);
     void showEditRules();

--- a/ui/AlertWidget.ui
+++ b/ui/AlertWidget.ui
@@ -50,7 +50,7 @@
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
+      <enum>QAbstractItemView::ExtendedSelection</enum>
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
@@ -129,9 +129,14 @@
     <string>Column Visibility...</string>
    </property>
   </action>
+  <action name="actionClearSelected">
+   <property name="text">
+    <string>Clear Selected</string>
+   </property>
+  </action>
   <action name="actionClear">
    <property name="text">
-    <string>Clear</string>
+    <string>Clear All</string>
    </property>
   </action>
  </widget>
@@ -202,6 +207,22 @@
    </hints>
   </connection>
   <connection>
+   <sender>actionClearSelected</sender>
+   <signal>triggered()</signal>
+   <receiver>AlertWidget</receiver>
+   <slot>clearSelectedAlerts()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>386</x>
+     <y>162</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>actionClear</sender>
    <signal>triggered()</signal>
    <receiver>AlertWidget</receiver>
@@ -220,6 +241,7 @@
  </connections>
  <slots>
   <slot>clearAllAlerts()</slot>
+  <slot>clearSelectedAlerts()</slot>
   <slot>entryDoubleClicked(QModelIndex)</slot>
   <slot>alertAgingChanged(int)</slot>
   <slot>showEditRules()</slot>

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -928,7 +928,7 @@
   </action>
   <action name="actionClearAlerts">
    <property name="text">
-    <string>Clear</string>
+    <string>Clear All</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>


### PR DESCRIPTION
Add a new feature to clear individual selected alerts from the alert table. Changed selection mode from SingleSelection to ExtendedSelection to allow multiple row selection, added a new 'Clear Selected' action, and renamed existing 'Clear' actions to 'Clear All' for clarity.

I've been got lots of 'New Entity' alerts and it will be for stations using weird suffixes.  Or would like to be able to clear stations if I work them or just don't want to see it.