### PR TITLE
Add Mark QSL Sent action to the QSO context menu

### DIFF
--- a/ui/LogbookWidget.cpp
+++ b/ui/LogbookWidget.cpp
@@ -145,11 +145,13 @@ LogbookWidget::LogbookWidget(QWidget *parent) :
     ui->contactTable->addAction(ui->actionDisplayedColumns);
     ui->contactTable->addAction(separator2);
     ui->contactTable->addAction(ui->actionQSLRcvd);
+    ui->contactTable->addAction(ui->actionQSLSent);
     ui->contactTable->addAction(ui->actionQSLRequested);
     ui->contactTable->addAction(separator3);
     ui->contactTable->addAction(ui->actionDeleteContact);
 
     connect(ui->actionQSLRcvd, &QAction::triggered, this, &LogbookWidget::markQslReceived);
+    connect(ui->actionQSLSent, &QAction::triggered, this, &LogbookWidget::markQslSent);
     connect(ui->actionQSLRequested, &QAction::triggered, this, &LogbookWidget::markQslRequested);
 
     ui->contactTable->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -1242,6 +1244,17 @@ void LogbookWidget::markQslReceived()
     {
         model->setData(model->index(row, LogbookModel::COLUMN_QSL_RCVD), "Y", Qt::EditRole);
         model->setData(model->index(row, LogbookModel::COLUMN_QSL_RCVD_DATE), QDate::currentDate(), Qt::EditRole);
+    });
+}
+
+void LogbookWidget::markQslSent()
+{
+    FCT_IDENTIFICATION;
+
+    updateSelectedRows([this](int row)
+    {
+        model->setData(model->index(row, LogbookModel::COLUMN_QSL_SENT), "Y", Qt::EditRole);
+        model->setData(model->index(row, LogbookModel::COLUMN_QSL_SENT_DATE), QDate::currentDate(), Qt::EditRole);
     });
 }
 

--- a/ui/LogbookWidget.h
+++ b/ui/LogbookWidget.h
@@ -81,6 +81,7 @@ public slots:
     void saveTableHeaderState();
     void showTableHeaderContextMenu(const QPoint& point);
     void markQslReceived();
+    void markQslSent();
     void markQslRequested();
     void doubleClickColumn(QModelIndex);
     void handleBeforeUpdate(int, QSqlRecord&);

--- a/ui/LogbookWidget.ui
+++ b/ui/LogbookWidget.ui
@@ -283,6 +283,11 @@
     <string>Mark QSL RCVD</string>
    </property>
   </action>
+  <action name="actionQSLSent">
+   <property name="text">
+    <string>Mark QSL Sent</string>
+   </property>
+  </action>
   <action name="actionQSLRequested">
    <property name="text">
     <string>Mark QSL Requested</string>


### PR DESCRIPTION
## Description
This PR adds a new Mark QSL Sent action to the QSO right-click menu in the logbook.
The behavior matches the existing Mark QSL Received flow: it updates the selected QSO rows by setting QSL Sent = Y and filling QSL Sent Date with the current date.