### PR TITLE
Statistics: Add QSO histogram by operator callsign

### DIFF
--- a/ui/StatisticsWidget.cpp
+++ b/ui/StatisticsWidget.cpp
@@ -282,6 +282,7 @@ void StatisticsWidget::refreshGraph()
          switch ( ui->statTypeSecCombo->currentIndex() )
          {
          case 0:  // Distance
+         {
              QString distCoef = QString::number(Gridsquare::localeDistanceCoef(locale));
              stmt = QString("WITH hist AS ( "
                     " SELECT CAST((distance * %1)/500.00 AS INTEGER) * 500 as dist_floor, "
@@ -295,6 +296,12 @@ void StatisticsWidget::refreshGraph()
                     "SELECT dist_floor as dist_range, count "
                     " FROM hist "
                     " ORDER BY 1").arg(distCoef);
+             break;
+         }
+         case 1:  // Operator callsigns
+             stmt = "SELECT COALESCE(NULLIF(TRIM(operator), ''), '" + tr("Not specified") + "'), COUNT(1) "
+                    "FROM contacts WHERE " + genericFilter.join(" AND ") + " "
+                    "GROUP BY 1 ORDER BY 2 DESC, 1";
              break;
          }
 
@@ -723,6 +730,7 @@ void StatisticsWidget::setSubTypesCombo(int mainTypeIdx)
         QString unit;
         Gridsquare::distance2localeUnitDistance(0, unit, locale);
         ui->statTypeSecCombo->addItem(tr("Distance") + QString(" [%1]").arg(unit));
+        ui->statTypeSecCombo->addItem(tr("Operator Callsign"));
     }
     break;
 


### PR DESCRIPTION
# Description

This PR adds an Operator Callsign option to the Statistics histogram.

The new chart:

Uses operator callsigns on the horizontal axis.
Displays QSO counts on the vertical axis.
Sorts operators by QSO count.
Groups empty operator values under Not specified.
Respects the existing date, band, station and user filters.

This is useful for club and multi-operator stations to compare the number of QSOs logged by each operator.

# Testing

Verified the aggregation query against a local QLog database.
Verified that the newly built application starts and remains responsive.
<img width="1850" height="1120" alt="2 TF@AMSEYSAA)_UB5~SIC7" src="https://github.com/user-attachments/assets/c94099f3-871f-4e93-89a8-4589cd03a744" />
