### PR TITLE
Recommend Translate

### DIFF
--- a/i18n/qlog_zh_CN.ts
+++ b/i18n/qlog_zh_CN.ts
@@ -3896,7 +3896,7 @@
     <message>
         <location filename="dbstrings.tri" line="265"/>
         <source>Scarborough Reef</source>
-        <translation>斯卡伯勒礁</translation>
+        <translation>黄岩岛（民主礁）</translation>
     </message>
     <message>
         <location filename="dbstrings.tri" line="266"/>


### PR DESCRIPTION
Hello developer !
I notice the issue 1129 which is about Scarborough Reef.
I strongly agree that Qlog software should remain neutral.However, when translating into Chinese, I believe we should follow the conventions that locals are accustomed to.
As you mentioned, there are some historical issues between the People's Republic of China and Taiwan Province. However, regardless of which side refers to this place, it is not the current translation
So I would like to recommend that you translate Scarborough Reef as 黄岩岛 (民主礁)
﻿
Thank you !
De BG2GBQ