### PR TITLE
Fix EQSL abort crash

### DIFF
--- a/service/eqsl/Eqsl.cpp
+++ b/service/eqsl/Eqsl.cpp
@@ -384,7 +384,7 @@ void EQSLQSLDownloader::abortDownload()
     if ( currentReply )
     {
         currentReply->abort();
-        currentReply->deleteLater();
+        currentReply = nullptr;
     }
 }
 


### PR DESCRIPTION
When aborting an active EQSL download, clear the active reply pointer instead of deferring deletion. This prevents stale reply objects from lingering after cancellation and keeps the downloader state consistent. #1138